### PR TITLE
fix(subscription): do not modify lastSequenceNumber for PullCatchUp

### DIFF
--- a/subscription/pull_catchtup.go
+++ b/subscription/pull_catchtup.go
@@ -111,15 +111,15 @@ func (s *PullCatchUp) catchUp(
 
 	// NOTE: incrementing the sequence number by one so that we skip potential
 	// duplicates due to inclusive selecting operators.
-	lastSequenceNumber++
+	selectFrom := eventstore.Select{From: lastSequenceNumber + 1}
 
 	group, ctx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		switch t := s.Target.(type) {
 		case TargetStreamAll:
-			return s.EventStore.StreamAll(ctx, es, eventstore.Select{From: lastSequenceNumber})
+			return s.EventStore.StreamAll(ctx, es, selectFrom)
 		case TargetStreamType:
-			return s.EventStore.StreamByType(ctx, es, t.Type, eventstore.Select{From: lastSequenceNumber})
+			return s.EventStore.StreamByType(ctx, es, t.Type, selectFrom)
 		default:
 			return fmt.Errorf("subscription.PullCatchUp: unexpected target type")
 		}


### PR DESCRIPTION
The current implementation in `subscription.PullCatchUp` increments the `lastSequenceNumber` value before doing any streaming operation, then returns that value as the value received by the Event Store (which might not be true, if there are no events in the next batch streamed).

This PR fixes this behavior.

Note: this was discovered after introducing logging in #33 ✨ 