### PR TITLE
feat(eventstore): add Registry for type deserialization

### DIFF
--- a/eventstore/registry.go
+++ b/eventstore/registry.go
@@ -1,0 +1,90 @@
+package eventstore
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/get-eventually/go-eventually"
+)
+
+// DeserializerFn is a function that deserializes a raw input into a Go type,
+// which is passed here as interface{}, typically by reference.
+type DeserializerFn func(msg []byte, v interface{}) error
+
+// Registry contains type information about events to deserialize,
+// and the deserialization function, when retrieving events from an Event Store.
+//
+// Given the current limitation of Go with generics, the only way to provide
+// type information for deserialization is to use interfaces and reflection.
+// This component uses the event type identifier and reflection to deserialize
+// messages coming from the Event Store.
+type Registry struct {
+	deserializerFn  DeserializerFn
+	eventNameToType map[string]reflect.Type
+	eventTypeToName map[reflect.Type]string
+}
+
+// NewRegistry creates a new registry for deserializing event types, using
+// the provided deserializer.
+//
+// An error is returned if the deserializer is nil.
+func NewRegistry(deserializer DeserializerFn) (Registry, error) {
+	if deserializer == nil {
+		return Registry{}, fmt.Errorf("eventstore.Registry: invalid deserializer provided")
+	}
+
+	return Registry{
+		deserializerFn:  deserializer,
+		eventNameToType: make(map[string]reflect.Type),
+		eventTypeToName: make(map[reflect.Type]string),
+	}, nil
+}
+
+// Register adds the type information to this registry for all the provided Payload types.
+//
+// An error is returned if any of the provided events is nil, or if two different event types
+// with the same type identifier (from the Payload.Name() method) have been provided.
+func (r Registry) Register(events ...eventually.Payload) error {
+	for _, event := range events {
+		if event == nil {
+			return fmt.Errorf("eventstore.Registry: expected event type, nil was provided instead")
+		}
+
+		eventName := event.Name()
+		eventType := reflect.TypeOf(event)
+
+		if registeredType, ok := r.eventNameToType[eventName]; ok {
+			if registeredType == eventType {
+				// Type is already registered and the new one is the same as the
+				// one already registered, so we can continue with the other event types.
+				continue
+			}
+
+			return fmt.Errorf(
+				"eventstore.Registry: event '%s' has been already registered with a different type",
+				eventName,
+			)
+		}
+
+		r.eventNameToType[eventName] = eventType
+		r.eventTypeToName[eventType] = eventName
+	}
+
+	return nil
+}
+
+// Deserialize attempts to deserialize a raw message with the type referenced by the
+// supplied event type identifier.
+func (r Registry) Deserialize(eventType string, payload []byte) (eventually.Payload, error) {
+	payloadType, ok := r.eventNameToType[eventType]
+	if !ok {
+		return nil, fmt.Errorf("eventstore.Registry: received unregistered event, '%s'", eventType)
+	}
+
+	vp := reflect.New(payloadType)
+	if err := r.deserializerFn(payload, vp.Interface()); err != nil {
+		return nil, fmt.Errorf("eventstore.Registry: failed to deserialize event: %w", err)
+	}
+
+	return vp.Elem().Interface().(eventually.Payload), nil
+}

--- a/eventstore/registry_test.go
+++ b/eventstore/registry_test.go
@@ -1,0 +1,141 @@
+package eventstore_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/get-eventually/go-eventually"
+	"github.com/get-eventually/go-eventually/eventstore"
+	"github.com/get-eventually/go-eventually/internal"
+)
+
+func TestNewRegistry(t *testing.T) {
+	t.Run("initialize with nil deserializer fails", func(t *testing.T) {
+		r, err := eventstore.NewRegistry(nil)
+		assert.Zero(t, r)
+		assert.Error(t, err)
+	})
+
+	t.Run("initialize with proper deserializer", func(t *testing.T) {
+		r, err := eventstore.NewRegistry(json.Unmarshal)
+		assert.NotZero(t, r)
+		assert.NoError(t, err)
+	})
+}
+
+type event1 struct{}
+
+//nolint:goconst // This is used for testing, it's ok not to define a constant.
+func (event1) Name() string { return "test_event" }
+
+type event2 int
+
+func (event2) Name() string { return "test_event" }
+
+type event3 struct {
+	Field string `json:"field"`
+}
+
+func (event3) Name() string { return "test_event_3" }
+
+func TestRegistry_Register(t *testing.T) {
+	type testcase struct {
+		input   []eventually.Payload
+		wantErr bool
+	}
+
+	testcases := map[string]testcase{
+		"no events, no registration, no failures": {},
+		"registering a nil event fails": {
+			input:   []eventually.Payload{nil},
+			wantErr: true,
+		},
+		"registering a proper event works": {
+			input: []eventually.Payload{internal.IntPayload(0)},
+		},
+		"registering the same event twice has no bad effect": {
+			input: []eventually.Payload{
+				internal.IntPayload(0),
+				internal.IntPayload(0),
+			},
+		},
+		"registering two different events with the same name fails": {
+			input: []eventually.Payload{
+				event1{},
+				event2(0),
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testcases {
+		name, tc := name, tc
+
+		t.Run(name, func(t *testing.T) {
+			r, err := eventstore.NewRegistry(json.Unmarshal)
+			require.NoError(t, err)
+
+			err = r.Register(tc.input...)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRegistry_Deserialize(t *testing.T) {
+	type testcase struct {
+		input     []byte
+		eventType string
+		expected  eventually.Payload
+		wantErr   bool
+	}
+
+	testcases := map[string]testcase{
+		"deserializing an unregistered event fails": {
+			eventType: event1{}.Name(),
+			wantErr:   true,
+		},
+		"if deserializer function fails, then failure is propagated": {
+			input:     []byte("1"), // Invalid JSON representation of the event.
+			eventType: event3{}.Name(),
+			wantErr:   true,
+		},
+		"deserializer works": {
+			input:     []byte(`{"field":"it works!"}`),
+			eventType: event3{}.Name(),
+			expected:  event3{Field: "it works!"},
+		},
+	}
+
+	for name, tc := range testcases {
+		name, tc := name, tc
+
+		t.Run(name, func(t *testing.T) {
+			r, err := eventstore.NewRegistry(json.Unmarshal)
+			require.NoError(t, err)
+
+			require.NoError(t, r.Register(
+				internal.IntPayload(0),
+				internal.StringPayload(""),
+				event3{},
+			))
+
+			actual, err := r.Deserialize(tc.eventType, tc.input)
+
+			if tc.wantErr {
+				assert.Nil(t, actual)
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tc.expected, actual)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
First PR for #38 is to add the centralized Event Registry.
