### PR TITLE
feat(postgres): point to main eventually module, remove Subscriber methods and simplify API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 PKG = github.com/get-eventually/go-eventually
+GO_TEST_FLAGS := -race -v
 
 .PHONY: postgres-tests
 postgres-tests:
-	@cd ./eventstore/postgres && go test -race -v -coverprofile=postgres.out ./...
+	@cd ./eventstore/postgres && go test $(GO_TEST_FLAGS) -coverprofile=postgres.out ./...
 	@cd ./eventstore/postgres && go tool cover -func=postgres.out
 
 .PHONY: eventually-tests
 eventually-tests:
-	@go test -short -race -v -coverprofile=eventually.out -coverpkg=${PKG}/... ./...
+	@go test $(GO_TEST_FLAGS) -coverprofile=eventually.out ./...
 	@go tool cover -func=eventually.out

--- a/eventstore/postgres/checkpointer_test.go
+++ b/eventstore/postgres/checkpointer_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/get-eventually/go-eventually/eventstore/postgres"
@@ -13,11 +12,8 @@ import (
 )
 
 func TestCheckpointer(t *testing.T) {
-	store := obtainEventStore(t)
-	defer func() { assert.NoError(t, store.Close()) }()
-
-	db, err := openDB()
-	require.NoError(t, err)
+	db, _ := obtainEventStore(t)
+	defer func() { assert.NoError(t, db.Close()) }()
 
 	log := zaplogger.Wrap(zap.NewNop())
 	ctx := context.Background()

--- a/eventstore/postgres/go.mod
+++ b/eventstore/postgres/go.mod
@@ -2,6 +2,8 @@ module github.com/get-eventually/go-eventually/eventstore/postgres
 
 go 1.15
 
+replace github.com/get-eventually/go-eventually => ../../
+
 require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/containerd/containerd v1.4.3 // indirect
@@ -9,11 +11,11 @@ require (
 	github.com/docker/docker v20.10.2+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/get-eventually/go-eventually v0.0.0-20210823224756-746a3204cbea
+	github.com/get-eventually/go-eventually v0.0.0-00010101000000-000000000000
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-migrate/migrate v3.5.4+incompatible
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/lib/pq v1.10.1
+	github.com/lib/pq v1.10.1 // indirect
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/eventstore/postgres/go.sum
+++ b/eventstore/postgres/go.sum
@@ -30,8 +30,6 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/get-eventually/go-eventually v0.0.0-20210823224756-746a3204cbea h1:GEOAraPCORCyOBPxOULH8Qg9Jbe38/bIgCrUjJ1qKcU=
-github.com/get-eventually/go-eventually v0.0.0-20210823224756-746a3204cbea/go.mod h1:0zLn6xjbuLiB2D30+HDSrYp7AOE2uSXZgBay6WWmFwM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-migrate/migrate v3.5.4+incompatible h1:R7OzwvCJTCgwapPCiX6DyBiu2czIUMDCB118gFTKTUA=

--- a/eventstore/postgres/store.go
+++ b/eventstore/postgres/store.go
@@ -1,82 +1,42 @@
 package postgres
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/get-eventually/go-eventually"
 	"github.com/get-eventually/go-eventually/eventstore"
 
 	_ "github.com/golang-migrate/migrate/database/postgres" // postgres driver for migrate
-	"github.com/lib/pq"
 )
-
-const (
-	streamAllName = "$all"
-
-	// DefaultNotifyChannelTimeout is the default refresh timeout for each
-	// notifications received through LISTEN.
-	DefaultNotifyChannelTimeout = 10 * time.Second
-
-	// DefaultReconnectionTimeout is the minimum timeout value the database driver
-	// uses before re-establishing a connection with the database when
-	// the previous one had been closed.
-	DefaultReconnectionTimeout = 10 * time.Second
-)
-
-// ErrEmptyEventsMap occurs during a call to Register where a nil or empty Events map
-// is provided, which would mean no events would be registered for the desired type.
-var ErrEmptyEventsMap = fmt.Errorf("postgres.EventStore: empty events map provided for type")
 
 var _ eventstore.Store = &EventStore{}
 
 // EventStore is an eventstore.Store implementation which uses
 // PostgreSQL as backend datastore.
 type EventStore struct {
-	dsn      string
 	db       *sql.DB
 	registry eventstore.Registry
 }
 
-// OpenEventStore opens a connection with the PostgreSQL identified by the provided DSN.
-// Make sure to perform migrations first by running postgres.RunMigrations() function.
-func OpenEventStore(dsn string) (*EventStore, error) {
-	db, err := sql.Open("postgres", dsn)
-	if err != nil {
-		return nil, fmt.Errorf("postgres.EventStore: failed to open connection with the db: %w", err)
-	}
-
-	registry, err := eventstore.NewRegistry(json.Unmarshal)
-	if err != nil {
-		return nil, fmt.Errorf("postgres.EventStore: failed to initialize event registry: %w", err)
-	}
-
-	return &EventStore{
+func NewEventStore(db *sql.DB) EventStore {
+	return EventStore{
 		db:       db,
-		dsn:      dsn,
-		registry: registry,
-	}, nil
-}
-
-// Close closes the Event Store database connection.
-func (st *EventStore) Close() error {
-	return st.db.Close()
+		registry: eventstore.NewRegistry(json.Unmarshal),
+	}
 }
 
 // Register registers Domain Events used by the application in order to decode events
 // stored in the database by their name returned by the eventually.Payload trait.
-func (st *EventStore) Register(events ...eventually.Payload) error {
-	// TODO(ar3s3ru): get the registry injected instead of creating it in OpenEventStore().
+func (st EventStore) Register(events ...eventually.Payload) error {
 	return st.registry.Register(events...)
 }
 
 // StreamAll opens an Event Stream and sinks all the events in the Event Store in the provided
 // channel, skipping those events with a sequence number lower than the provided bound.
-func (st *EventStore) StreamAll(ctx context.Context, es eventstore.EventStream, selectt eventstore.Select) error {
+func (st EventStore) StreamAll(ctx context.Context, es eventstore.EventStream, selectt eventstore.Select) error {
 	defer close(es)
 
 	rows, err := st.db.QueryContext(
@@ -98,7 +58,7 @@ func (st *EventStore) StreamAll(ctx context.Context, es eventstore.EventStream, 
 // as specified in input.
 //
 // The stream will be ordered based on their Global Sequence Number.
-func (st *EventStore) StreamByType(
+func (st EventStore) StreamByType(
 	ctx context.Context,
 	es eventstore.EventStream,
 	typ string,
@@ -123,7 +83,7 @@ func (st *EventStore) StreamByType(
 }
 
 // Stream opens the specific Event Stream identified by the provided id.
-func (st *EventStore) Stream(
+func (st EventStore) Stream(
 	ctx context.Context,
 	es eventstore.EventStream,
 	id eventstore.StreamID,
@@ -148,111 +108,6 @@ func (st *EventStore) Stream(
 	return rowsToStream(rows, es, st.registry, nil)
 }
 
-type rawNotificationEvent struct {
-	StreamID       string              `json:"stream_id"`
-	StreamType     string              `json:"stream_type"`
-	EventType      string              `json:"event_type"`
-	Version        int64               `json:"version"`
-	SequenceNumber int64               `json:"sequence_number"`
-	Event          json.RawMessage     `json:"event"`
-	Metadata       eventually.Metadata `json:"metadata"`
-}
-
-// SubscribeToAll subscribes to all the new Events committed to the Event Store
-// and sinks them in the provided channel.
-func (st *EventStore) SubscribeToAll(ctx context.Context, es eventstore.EventStream) error {
-	return st.subscribe(ctx, streamAllName, es)
-}
-
-// SubscribeToType subscribes to all the new Events of the specified Stream Type
-// committed to the Event Store and sinks them in the provided channel.
-func (st *EventStore) SubscribeToType(ctx context.Context, es eventstore.EventStream, typ string) error {
-	return st.subscribe(ctx, typ, es)
-}
-
-func (st *EventStore) subscribe(ctx context.Context, name string, es eventstore.EventStream) (err error) {
-	defer close(es)
-
-	listener := pq.NewListener(
-		st.dsn,
-		DefaultReconnectionTimeout,
-		time.Minute,
-		func(ev pq.ListenerEventType, err error) {
-			if err != nil {
-				fmt.Println(err.Error())
-			}
-		},
-	)
-
-	if err = listener.Listen(name); err != nil {
-		return fmt.Errorf("postgres.EventStore: failed to listen on stream: %w", err)
-	}
-
-	// TODO: proper error handling!
-	defer func() {
-		//nolint:errcheck,gosec // Skipping proper error handling for now, as it would require
-		//                         logging and we haven't set that up yet in here.
-		listener.Close()
-	}()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("postgres.EventStore: listener closed: %w", ctx.Err())
-
-		case <-time.After(DefaultNotifyChannelTimeout):
-			if err = listener.Ping(); err != nil {
-				return fmt.Errorf("postgres.EventStore: failed to ping listener: %w", err)
-			}
-
-		case notification := <-listener.Notify:
-			if notification == nil {
-				continue
-			}
-
-			event, err := st.processNotification(notification)
-			if err != nil {
-				return err
-			}
-
-			es <- event
-		}
-	}
-}
-
-func (st *EventStore) processNotification(notification *pq.Notification) (eventstore.Event, error) {
-	buffer := bytes.NewBufferString(notification.Extra)
-
-	var rawEvent rawNotificationEvent
-	if err := json.NewDecoder(buffer).Decode(&rawEvent); err != nil {
-		return eventstore.Event{}, fmt.Errorf(
-			"postgres.EventStore: failed to unmarshal notification payload into event: %w",
-			err,
-		)
-	}
-
-	payload, err := st.registry.Deserialize(rawEvent.EventType, rawEvent.Event)
-	if err != nil {
-		return eventstore.Event{}, fmt.Errorf(
-			"postgres.EventStore: failed to unmarshal event payload from json: %w",
-			err,
-		)
-	}
-
-	return eventstore.Event{
-		Stream: eventstore.StreamID{
-			Type: rawEvent.StreamType,
-			Name: rawEvent.StreamID,
-		},
-		Version:        rawEvent.Version,
-		SequenceNumber: rawEvent.SequenceNumber,
-		Event: eventually.Event{
-			Payload:  payload,
-			Metadata: rawEvent.Metadata,
-		},
-	}, nil
-}
-
 // Append inserts the specified Domain Events into the Event Stream specified
 // by the current instance, returning the new version of the Event Stream.
 //
@@ -265,7 +120,7 @@ func (st *EventStore) processNotification(notification *pq.Notification) (events
 //
 // NOTE: this implementation is not returning yet eventstore.ErrConflict in case
 // of conflicting expectations with the provided VersionCheck value.
-func (st *EventStore) Append(
+func (st EventStore) Append(
 	ctx context.Context,
 	id eventstore.StreamID,
 	expected eventstore.VersionCheck,

--- a/eventstore/registry.go
+++ b/eventstore/registry.go
@@ -26,18 +26,12 @@ type Registry struct {
 
 // NewRegistry creates a new registry for deserializing event types, using
 // the provided deserializer.
-//
-// An error is returned if the deserializer is nil.
-func NewRegistry(deserializer DeserializerFn) (Registry, error) {
-	if deserializer == nil {
-		return Registry{}, fmt.Errorf("eventstore.Registry: invalid deserializer provided")
-	}
-
+func NewRegistry(deserializer DeserializerFn) Registry {
 	return Registry{
 		deserializerFn:  deserializer,
 		eventNameToType: make(map[string]reflect.Type),
 		eventTypeToName: make(map[reflect.Type]string),
-	}, nil
+	}
 }
 
 // Register adds the type information to this registry for all the provided Payload types.

--- a/eventstore/registry_test.go
+++ b/eventstore/registry_test.go
@@ -12,20 +12,6 @@ import (
 	"github.com/get-eventually/go-eventually/internal"
 )
 
-func TestNewRegistry(t *testing.T) {
-	t.Run("initialize with nil deserializer fails", func(t *testing.T) {
-		r, err := eventstore.NewRegistry(nil)
-		assert.Zero(t, r)
-		assert.Error(t, err)
-	})
-
-	t.Run("initialize with proper deserializer", func(t *testing.T) {
-		r, err := eventstore.NewRegistry(json.Unmarshal)
-		assert.NotZero(t, r)
-		assert.NoError(t, err)
-	})
-}
-
 type event1 struct{}
 
 //nolint:goconst // This is used for testing, it's ok not to define a constant.
@@ -75,10 +61,8 @@ func TestRegistry_Register(t *testing.T) {
 		name, tc := name, tc
 
 		t.Run(name, func(t *testing.T) {
-			r, err := eventstore.NewRegistry(json.Unmarshal)
-			require.NoError(t, err)
-
-			err = r.Register(tc.input...)
+			r := eventstore.NewRegistry(json.Unmarshal)
+			err := r.Register(tc.input...)
 
 			if tc.wantErr {
 				assert.Error(t, err)
@@ -118,8 +102,7 @@ func TestRegistry_Deserialize(t *testing.T) {
 		name, tc := name, tc
 
 		t.Run(name, func(t *testing.T) {
-			r, err := eventstore.NewRegistry(json.Unmarshal)
-			require.NoError(t, err)
+			r := eventstore.NewRegistry(json.Unmarshal)
 
 			require.NoError(t, r.Register(
 				internal.IntPayload(0),


### PR DESCRIPTION
Closes #37.

- refactor(eventstore): make Registry easier to create
- feat(postgres): point to same eventually module
- refactor(postgres): remove Subscriber methods and simplify API
