### PR TITLE
chore(inmemory): remove deprecated Subscriber interface

### DIFF
--- a/eventstore/postgres/go.mod
+++ b/eventstore/postgres/go.mod
@@ -2,8 +2,6 @@ module github.com/get-eventually/go-eventually/eventstore/postgres
 
 go 1.15
 
-replace github.com/get-eventually/go-eventually => ../../
-
 require (
 	github.com/Microsoft/go-winio v0.4.16 // indirect
 	github.com/containerd/containerd v1.4.3 // indirect
@@ -11,7 +9,7 @@ require (
 	github.com/docker/docker v20.10.2+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/get-eventually/go-eventually v0.0.0-00010101000000-000000000000
+	github.com/get-eventually/go-eventually v0.0.0-20210825075251-35c80b0b6985
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-migrate/migrate v3.5.4+incompatible
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/eventstore/postgres/go.sum
+++ b/eventstore/postgres/go.sum
@@ -30,6 +30,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/get-eventually/go-eventually v0.0.0-20210825075251-35c80b0b6985 h1:zdtaEOd4Bmom7ECs4sDbMLXIZm64pBNeFe8ruW/8JKo=
+github.com/get-eventually/go-eventually v0.0.0-20210825075251-35c80b0b6985/go.mod h1:0zLn6xjbuLiB2D30+HDSrYp7AOE2uSXZgBay6WWmFwM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-migrate/migrate v3.5.4+incompatible h1:R7OzwvCJTCgwapPCiX6DyBiu2czIUMDCB118gFTKTUA=


### PR DESCRIPTION
- refactor(inmemory): remove Subscriber interface implementation
- fix(postgres): point to explicit go-eventually version
