### PR TITLE
refactor(eventstore): change Streamer interface to a single method, introduce Event Stream targets type

### DIFF
--- a/command/error_recorder.go
+++ b/command/error_recorder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/get-eventually/go-eventually"
 	"github.com/get-eventually/go-eventually/eventstore"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
 )
 
 // FailedType is the default stream type used by ErrorRecorder
@@ -58,13 +59,13 @@ func (er ErrorRecorder) streamType() string {
 	return FailedType
 }
 
-func (er ErrorRecorder) buildStreamID(cmd eventually.Command) eventstore.StreamID {
+func (er ErrorRecorder) buildStreamID(cmd eventually.Command) stream.ID {
 	streamName := cmd.Payload.Name()
 	if er.StreamNameMapper != nil {
 		streamName = er.StreamNameMapper(cmd)
 	}
 
-	return eventstore.StreamID{
+	return stream.ID{
 		Type: er.streamType(),
 		Name: streamName,
 	}

--- a/command/error_recorder_test.go
+++ b/command/error_recorder_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/get-eventually/go-eventually/command"
 	"github.com/get-eventually/go-eventually/eventstore"
 	"github.com/get-eventually/go-eventually/eventstore/inmemory"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
 )
 
 type mockCommand struct {
@@ -84,7 +85,7 @@ func TestErrorRecorder(t *testing.T) {
 		assert.Equal(t, []eventstore.Event{
 			{
 				Version: 1,
-				Stream: eventstore.StreamID{
+				Stream: stream.ID{
 					Type: command.FailedType,
 					Name: expectedCommand.Payload.Name(),
 				},
@@ -127,7 +128,7 @@ func TestErrorRecorder(t *testing.T) {
 		assert.Equal(t, []eventstore.Event{
 			{
 				Version: 1,
-				Stream: eventstore.StreamID{
+				Stream: stream.ID{
 					Type: command.FailedType,
 					Name: expectedCommand.Payload.Name(),
 				},
@@ -172,7 +173,7 @@ func TestErrorRecorder(t *testing.T) {
 		assert.Equal(t, []eventstore.Event{
 			{
 				Version: 1,
-				Stream: eventstore.StreamID{
+				Stream: stream.ID{
 					Type: expectedStreamType,
 					Name: expectedCommand.Payload.Name(),
 				},
@@ -219,7 +220,7 @@ func TestErrorRecorder(t *testing.T) {
 		assert.Equal(t, []eventstore.Event{
 			{
 				Version: 1,
-				Stream: eventstore.StreamID{
+				Stream: stream.ID{
 					Type: expectedStreamType,
 					Name: expectedCommand.Payload.(mockCommand).message,
 				},

--- a/eventstore/example_fuse_test.go
+++ b/eventstore/example_fuse_test.go
@@ -9,9 +9,10 @@ import (
 
 func ExampleFused() {
 	eventStore := inmemory.NewEventStore()
-	correlatedEventStore := correlation.WrapEventStore(eventStore, func() string {
-		return "test-id"
-	})
+	correlatedEventStore := correlation.EventStoreWrapper{
+		Appender:  eventStore,
+		Generator: func() string { return "test-id" },
+	}
 
 	aggregate.NewRepository(aggregate.Type{}, eventstore.Fused{
 		Appender: correlatedEventStore,

--- a/eventstore/inmemory/store.go
+++ b/eventstore/inmemory/store.go
@@ -104,10 +104,6 @@ func (s *EventStore) streamByID(
 	id stream.ID,
 	selectt eventstore.Select,
 ) error {
-	s.mx.RLock()
-	defer s.mx.RUnlock()
-	defer close(es)
-
 	if m, ok := s.byTypeAndInstance[id.Type]; !ok || m == nil {
 		return nil
 	}

--- a/eventstore/inmemory/tracking.go
+++ b/eventstore/inmemory/tracking.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/get-eventually/go-eventually"
 	"github.com/get-eventually/go-eventually/eventstore"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
 )
 
 // TrackingEventStore is an Event Store wrapper to track the Events
@@ -45,7 +46,7 @@ func (es *TrackingEventStore) Recorded() []eventstore.Event {
 // The recorded events can be accessed by calling Recorded().
 func (es *TrackingEventStore) Append(
 	ctx context.Context,
-	id eventstore.StreamID,
+	id stream.ID,
 	expected eventstore.VersionCheck,
 	events ...eventually.Event,
 ) (int64, error) {

--- a/eventstore/inmemory/tracking_test.go
+++ b/eventstore/inmemory/tracking_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/get-eventually/go-eventually"
 	"github.com/get-eventually/go-eventually/eventstore"
 	"github.com/get-eventually/go-eventually/eventstore/inmemory"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
 	"github.com/get-eventually/go-eventually/internal"
 )
 
@@ -24,7 +25,7 @@ func TestTrackingEventStore(t *testing.T) {
 		eventStore := inmemory.NewEventStore()
 		trackingEventStore := inmemory.NewTrackingEventStore(eventStore)
 
-		streamID := eventstore.StreamID{
+		streamID := stream.ID{
 			Type: "test-type",
 			Name: "test-instance",
 		}
@@ -43,7 +44,7 @@ func TestTrackingEventStore(t *testing.T) {
 
 		// Compare events in the event store and recorded ones from the tracking store.
 		events, err := eventstore.StreamToSlice(ctx, func(ctx context.Context, es eventstore.EventStream) error {
-			return eventStore.Stream(ctx, es, streamID, eventstore.SelectFromBeginning)
+			return eventStore.Stream(ctx, es, stream.ByID(streamID), eventstore.SelectFromBeginning)
 		})
 
 		assert.NoError(t, err)

--- a/eventstore/store_suite.go
+++ b/eventstore/store_suite.go
@@ -8,16 +8,17 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/get-eventually/go-eventually"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
 	"github.com/get-eventually/go-eventually/internal"
 )
 
 var (
-	firstInstance = StreamID{
+	firstInstance = stream.ID{
 		Type: "first-type",
 		Name: "my-instance",
 	}
 
-	secondInstance = StreamID{
+	secondInstance = stream.ID{
 		Type: "second-type",
 		Name: "my-instance",
 	}
@@ -134,7 +135,7 @@ func (ss *StoreSuite) TestStream() {
 
 	// Make sure the Event Store is completely empty.
 	streamAll, err := StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.StreamAll(ctx, es, SelectFromBeginning)
+		return ss.eventStore.Stream(ctx, es, stream.All{}, SelectFromBeginning)
 	})
 
 	assert.Empty(t, streamAll)
@@ -150,31 +151,31 @@ func (ss *StoreSuite) TestStream() {
 
 	// Make sure the Event Store has recorded the events as expected.
 	streamAll, err = StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.StreamAll(ctx, es, SelectFromBeginning)
+		return ss.eventStore.Stream(ctx, es, stream.All{}, SelectFromBeginning)
 	})
 
 	assert.NoError(t, err)
 
 	streamFirstType, err := StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.StreamByType(ctx, es, firstInstance.Type, SelectFromBeginning)
+		return ss.eventStore.Stream(ctx, es, stream.ByType(firstInstance.Type), SelectFromBeginning)
 	})
 
 	assert.NoError(t, err)
 
 	streamSecondType, err := StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.StreamByType(ctx, es, secondInstance.Type, SelectFromBeginning)
+		return ss.eventStore.Stream(ctx, es, stream.ByType(secondInstance.Type), SelectFromBeginning)
 	})
 
 	assert.NoError(t, err)
 
 	streamFirstInstance, err := StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.Stream(ctx, es, firstInstance, SelectFromBeginning)
+		return ss.eventStore.Stream(ctx, es, stream.ByID(firstInstance), SelectFromBeginning)
 	})
 
 	assert.NoError(t, err)
 
 	streamSecondInstance, err := StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.Stream(ctx, es, secondInstance, SelectFromBeginning)
+		return ss.eventStore.Stream(ctx, es, stream.ByID(secondInstance), SelectFromBeginning)
 	})
 
 	assert.NoError(t, err)
@@ -187,31 +188,31 @@ func (ss *StoreSuite) TestStream() {
 
 	// Streaming with an out-of-bound Select will yield empty elements.
 	streamAll, err = StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.StreamAll(ctx, es, Select{From: 7})
+		return ss.eventStore.Stream(ctx, es, stream.All{}, Select{From: 7})
 	})
 
 	assert.NoError(t, err)
 
 	streamFirstType, err = StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.StreamByType(ctx, es, firstInstance.Type, Select{From: 7})
+		return ss.eventStore.Stream(ctx, es, stream.ByType(firstInstance.Type), Select{From: 7})
 	})
 
 	assert.NoError(t, err)
 
 	streamSecondType, err = StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.StreamByType(ctx, es, secondInstance.Type, Select{From: 7})
+		return ss.eventStore.Stream(ctx, es, stream.ByType(secondInstance.Type), Select{From: 7})
 	})
 
 	assert.NoError(t, err)
 
 	streamFirstInstance, err = StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.Stream(ctx, es, firstInstance, Select{From: 4})
+		return ss.eventStore.Stream(ctx, es, stream.ByID(firstInstance), Select{From: 4})
 	})
 
 	assert.NoError(t, err)
 
 	streamSecondInstance, err = StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
-		return ss.eventStore.Stream(ctx, es, secondInstance, Select{From: 4})
+		return ss.eventStore.Stream(ctx, es, stream.ByID(secondInstance), Select{From: 4})
 	})
 
 	assert.NoError(t, err)

--- a/eventstore/store_suite.go
+++ b/eventstore/store_suite.go
@@ -156,6 +156,12 @@ func (ss *StoreSuite) TestStream() {
 
 	assert.NoError(t, err)
 
+	streamAllByTypes, err := StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
+		return ss.eventStore.Stream(ctx, es, stream.ByTypes{firstInstance.Type, secondInstance.Type}, SelectFromBeginning)
+	})
+
+	assert.NoError(t, err)
+
 	streamFirstType, err := StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
 		return ss.eventStore.Stream(ctx, es, stream.ByType(firstInstance.Type), SelectFromBeginning)
 	})
@@ -181,6 +187,7 @@ func (ss *StoreSuite) TestStream() {
 	assert.NoError(t, err)
 
 	assert.Equal(t, expectedStreamAll, ss.skipMetadata(streamAll))
+	assert.Equal(t, expectedStreamAll, ss.skipMetadata(streamAllByTypes))
 	assert.Equal(t, expectedStreamFirstInstance, ss.skipMetadata(streamFirstType))
 	assert.Equal(t, expectedStreamFirstInstance, ss.skipMetadata(streamFirstInstance))
 	assert.Equal(t, expectedStreamSecondInstance, ss.skipMetadata(streamSecondType))
@@ -189,6 +196,12 @@ func (ss *StoreSuite) TestStream() {
 	// Streaming with an out-of-bound Select will yield empty elements.
 	streamAll, err = StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
 		return ss.eventStore.Stream(ctx, es, stream.All{}, Select{From: 7})
+	})
+
+	assert.NoError(t, err)
+
+	streamAllByTypes, err = StreamToSlice(ctx, func(ctx context.Context, es EventStream) error {
+		return ss.eventStore.Stream(ctx, es, stream.ByTypes{firstInstance.Type, secondInstance.Type}, Select{From: 7})
 	})
 
 	assert.NoError(t, err)
@@ -218,6 +231,7 @@ func (ss *StoreSuite) TestStream() {
 	assert.NoError(t, err)
 
 	assert.Empty(t, streamAll)
+	assert.Empty(t, streamAllByTypes)
 	assert.Empty(t, streamFirstType)
 	assert.Empty(t, streamSecondType)
 	assert.Empty(t, streamFirstInstance)

--- a/eventstore/stream.go
+++ b/eventstore/stream.go
@@ -6,9 +6,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// EventStream is a stream of persisted Events.
-type EventStream chan<- Event
-
 // StreamToSlice synchronously exhausts an EventStream to an Event slice,
 // and returns an error if the EventStream origin, passed here as a closure,
 // fails with an error.

--- a/eventstore/stream/doc.go
+++ b/eventstore/stream/doc.go
@@ -1,0 +1,3 @@
+// Package stream exports types for dealing with Event Streams, such as Event Stream ids
+// and Event Streams targets.
+package stream

--- a/eventstore/stream/stream.go
+++ b/eventstore/stream/stream.go
@@ -1,0 +1,41 @@
+package stream
+
+// ID represents the unique identifier for an Event Stream.
+type ID struct {
+	// Type is the type, or category, of the Event Stream to which this
+	// Event belong. Usually, this is the name of the Aggregate type.
+	Type string
+
+	// Name is the name of the Event Stream to which this Event belong.
+	// Usually, this is the string representation of the Aggregate id.
+	Name string
+}
+
+// Target represents one or more Event Streams using different discriminators.
+//
+// This is a sealed interface and implementations are only provided by this package.
+// If you want to add support for an additional target, add it in this file, implement
+// this interface and make sure users of this interface are updated correctly (e.g. Event Stores).
+type Target interface {
+	isStreamTarget()
+}
+
+// All selects all existing Event Streams.
+type All struct{}
+
+func (All) isStreamTarget() {}
+
+// ByType selects all Event Streams with the specified Stream Type identifier.
+type ByType string
+
+func (ByType) isStreamTarget() {}
+
+// ByTypes selects all Event Streams with the Stream Type identifiers in the provided list.
+type ByTypes []string
+
+func (ByTypes) isStreamTarget() {}
+
+// ByID selects a single Event Stream identified by the provided stream.ID.
+type ByID ID
+
+func (ByID) isStreamTarget() {}

--- a/extension/correlation/projection.go
+++ b/extension/correlation/projection.go
@@ -12,16 +12,8 @@ var _ projection.Applier = ProjectionWrapper{}
 // ProjectionWrapper is an extension component that adds Correlation
 // and Causation ids to the context of the underlying projection.Applier
 // instance, if found in the Message received in Apply.
-//
-// Use WrapProjection to create a new instance.
 type ProjectionWrapper struct {
-	applier projection.Applier
-}
-
-// WrapProjection wraps the specified projection.Applier instance
-// with a ProjectionWrapper extension component.
-func WrapProjection(applier projection.Applier) ProjectionWrapper {
-	return ProjectionWrapper{applier: applier}
+	Projection projection.Applier
 }
 
 // Apply applies the provided Event to the wrapped projection.Applier,
@@ -38,5 +30,5 @@ func (pw ProjectionWrapper) Apply(ctx context.Context, event eventstore.Event) e
 		ctx = WithCausationID(ctx, eventID)
 	}
 
-	return pw.applier.Apply(ctx, event)
+	return pw.Projection.Apply(ctx, event)
 }

--- a/extension/oteleventually/attributes.go
+++ b/extension/oteleventually/attributes.go
@@ -2,23 +2,13 @@ package oteleventually
 
 import "go.opentelemetry.io/otel/attribute"
 
-// Names of the OpenTelemetry spans created by the package.
-const (
-	StreamSpanName       = "EventStore.Stream"
-	StreamByTypeSpanName = "EventStore.StreamByType"
-	StreamAllSpanName    = "EventStore.StreamAll"
-	AppendSpanName       = "EventStore.Append"
-	ApplierSpanName      = "Projection.Applier"
-)
-
-// Metrics exported by this package.
-const (
-	ProjectionApplyMetric = "eventually.projection.apply.duration.ms"
-)
-
 var (
 	// ErrorAttribute is used with a metric when an error is recorded.
 	ErrorAttribute = attribute.Key("error")
+
+	// StreamTargetAttribute is the attribute identifier that contains the
+	// stream target value used for EventStore.Stream calls.
+	StreamTargetAttribute = attribute.Key("stream.target")
 
 	// StreamNameAttribute is the attribute identifier that contains the Stream name,
 	// or Stream instance id, when using an eventstore.Instanced.

--- a/extension/oteleventually/projection.go
+++ b/extension/oteleventually/projection.go
@@ -87,7 +87,7 @@ func (ip *InstrumentedProjection) Apply(ctx context.Context, event eventstore.Ev
 		attribute.Any("event", event),
 	)
 
-	ctx, span := ip.tracer.Start(ctx, ApplierSpanName, trace.WithAttributes(spanAttributes...))
+	ctx, span := ip.tracer.Start(ctx, "Projection.Apply", trace.WithAttributes(spanAttributes...))
 	defer span.End()
 
 	start := time.Now()

--- a/projection/projection_test.go
+++ b/projection/projection_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/get-eventually/go-eventually"
 	"github.com/get-eventually/go-eventually/eventstore"
 	"github.com/get-eventually/go-eventually/eventstore/inmemory"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
 	"github.com/get-eventually/go-eventually/internal"
 	"github.com/get-eventually/go-eventually/logger"
 	"github.com/get-eventually/go-eventually/projection"
@@ -19,7 +20,7 @@ import (
 	"github.com/get-eventually/go-eventually/subscription/checkpoint"
 )
 
-var streamID = eventstore.StreamID{
+var streamID = stream.ID{
 	Type: "my-type",
 	Name: "my-instance",
 }
@@ -54,7 +55,7 @@ func TestRunner(t *testing.T) {
 	// Create a new subscription to listen events from the event store
 	testSubscription := &subscription.CatchUp{
 		SubscriptionName: "test-subscription",
-		Target:           subscription.TargetStreamAll{},
+		Target:           stream.All{},
 		EventStore:       eventStore,
 		Checkpointer:     checkpoint.NopCheckpointer,
 		PullEvery:        10 * time.Millisecond,

--- a/subscription/catchup_test.go
+++ b/subscription/catchup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/get-eventually/go-eventually"
 	"github.com/get-eventually/go-eventually/eventstore"
 	"github.com/get-eventually/go-eventually/eventstore/inmemory"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
 	"github.com/get-eventually/go-eventually/extension/zaplogger"
 	"github.com/get-eventually/go-eventually/internal"
 	"github.com/get-eventually/go-eventually/subscription"
@@ -30,7 +31,7 @@ func TestCatchUp(t *testing.T) {
 		return &subscription.CatchUp{
 			SubscriptionName: t.Name(),
 			Checkpointer:     checkpoint.NopCheckpointer,
-			Target:           subscription.TargetStreamAll{},
+			Target:           stream.All{},
 			Logger:           zaplogger.Wrap(logger),
 			EventStore:       store,
 			PullEvery:        10 * time.Millisecond,
@@ -56,7 +57,7 @@ func (s *CatchUpSuite) SetupTest() {
 
 func (s *CatchUpSuite) TestCatchUp() {
 	s.Run("catch-up subscriptions will receive events from before the subscription has started", func() {
-		streamID := eventstore.StreamID{
+		streamID := stream.ID{
 			Type: "my-type",
 			Name: "my-instance",
 		}

--- a/subscription/subscription.go
+++ b/subscription/subscription.go
@@ -25,29 +25,3 @@ type Subscription interface {
 	Start(ctx context.Context, eventStream eventstore.EventStream) error
 	Checkpoint(ctx context.Context, event eventstore.Event) error
 }
-
-// TargetStream represents an Event Stream targeted by a Subscription.
-//
-// Please note, this is a marker interface.
-// The only two possible variants are StreamAll and StreamType.
-// Use these types instead of creating an instance type.
-type TargetStream interface {
-	isTargetStream()
-}
-
-// TargetStreamAll opens a Subscription that listens to all Events in the Event Store.
-type TargetStreamAll struct{}
-
-func (TargetStreamAll) isTargetStream() {
-	// NOTE: this is a marker interface implementation.
-}
-
-// TargetStreamType opens a Subscription that listens to all Events of a certain
-// Stream type, the one specified in the Type field.
-type TargetStreamType struct {
-	Type string
-}
-
-func (TargetStreamType) isTargetStream() {
-	// NOTE: this is a marker interface implementation.
-}

--- a/subscription/volatile_test.go
+++ b/subscription/volatile_test.go
@@ -20,7 +20,7 @@ package subscription_test
 // 	ctx, cancel := context.WithCancel(context.Background())
 // 	defer cancel()
 
-// 	streamID := eventstore.StreamID{
+// 	streamID := stream.ID{
 // 		Type: "my-type",
 // 		Name: "my-instance",
 // 	}


### PR DESCRIPTION
Targets for the Event Store `Stream` operations were so far hardcoded (e.g. `StreamAll`, `StreamByType`, `Stream`).  
This makes implementations and mocks a bit more verbose (due to the number of methods), but mainly more verbose to add additional targets for stream operations.

An example: streaming by multiple Event Stream types.

Normally, that would've required an additional method, and implementing the method for every implementation of eventstore.Streamer around.

However, we can simplify things and specify a sealed interface for representing Event Stream targets. So far, the supported targets are: *All*, *By one Stream type*, *By multiple Stream types*, *By a single Stream ID*.
