### PR TITLE
feat(eventstore): add ContextAware and ContextMetadata propagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
 - `X-Eventually-TraceId` and `X-Eventually-SpanId` metadata keys are recorded when using `oteleventually.InstrumentedEventStore.Append`.
+- Add `eventstore.ContextAware` and `eventstore.ContextMetadata` to set some Metadata in the context to be applied to all Domain Events appended to the Event Store.
 
 ### Changed
 - ...

--- a/eventstore/context.go
+++ b/eventstore/context.go
@@ -1,0 +1,60 @@
+package eventstore
+
+import (
+	"context"
+
+	"github.com/get-eventually/go-eventually"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
+)
+
+type metadataContextKey struct{}
+
+// ContextMetadata extends a provided context.Context instance with the provided
+// eventually.Metadata map. When using the ContextAware eventstore.Appender extension,
+// the provided Metadata map will be applied to all events passed during an Append() method call.
+func ContextMetadata(ctx context.Context, metadata eventually.Metadata) context.Context {
+	ctxMetadata := ctx.Value(metadataContextKey{})
+	if ctxMetadata == nil {
+		return context.WithValue(ctx, metadataContextKey{}, metadata)
+	}
+
+	// If metadata has been defined in the context already, then merge the new values
+	// with the already-existing metadata map.
+	ctxMetadata.(eventually.Metadata).Merge(metadata)
+
+	return ctx
+}
+
+// ContextAware is an eventstore.Appender extension that uses the eventually.Metadata map
+// provided in the context.Context used during an Append() call to extend the metadata
+// of each event being appended.
+//
+// Use ContextMetadata in conjunction with this type to make use of this feature.
+type ContextAware struct {
+	Appender
+}
+
+// NewContextAware extends the provided eventstore.Appender instance with a ContextAware version.
+func NewContextAware(appender Appender) ContextAware {
+	return ContextAware{Appender: appender}
+}
+
+// Append applies the eventually.Metadata map from the context.Context to all the events specified, if such
+// map has been provided using eventstore.ContextMetadata.
+//
+// The extended events are then appended to the Event Store using the base eventstore.Appender instance
+// provided during initialization.
+func (ca ContextAware) Append(ctx context.Context, id stream.ID, versionCheck VersionCheck, events ...eventually.Event) (int64, error) {
+	metadata, ok := ctx.Value(metadataContextKey{}).(eventually.Metadata)
+	if !ok {
+		return ca.Appender.Append(ctx, id, versionCheck, events...)
+	}
+
+	newEvents := make([]eventually.Event, 0, len(events))
+	for _, event := range events {
+		event.Metadata = event.Metadata.Merge(metadata)
+		newEvents = append(newEvents, event)
+	}
+
+	return ca.Appender.Append(ctx, id, versionCheck, newEvents...)
+}

--- a/eventstore/context.go
+++ b/eventstore/context.go
@@ -44,13 +44,19 @@ func NewContextAware(appender Appender) ContextAware {
 //
 // The extended events are then appended to the Event Store using the base eventstore.Appender instance
 // provided during initialization.
-func (ca ContextAware) Append(ctx context.Context, id stream.ID, versionCheck VersionCheck, events ...eventually.Event) (int64, error) {
+func (ca ContextAware) Append(
+	ctx context.Context,
+	id stream.ID,
+	versionCheck VersionCheck,
+	events ...eventually.Event,
+) (int64, error) {
 	metadata, ok := ctx.Value(metadataContextKey{}).(eventually.Metadata)
 	if !ok {
 		return ca.Appender.Append(ctx, id, versionCheck, events...)
 	}
 
 	newEvents := make([]eventually.Event, 0, len(events))
+
 	for _, event := range events {
 		event.Metadata = event.Metadata.Merge(metadata)
 		newEvents = append(newEvents, event)

--- a/eventstore/context_test.go
+++ b/eventstore/context_test.go
@@ -1,0 +1,46 @@
+package eventstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/get-eventually/go-eventually"
+	"github.com/get-eventually/go-eventually/eventstore"
+	"github.com/get-eventually/go-eventually/eventstore/inmemory"
+	"github.com/get-eventually/go-eventually/eventstore/stream"
+	"github.com/get-eventually/go-eventually/internal"
+)
+
+func TestContextAware(t *testing.T) {
+	eventStore := inmemory.NewEventStore()
+	trackingEventStore := inmemory.NewTrackingEventStore(eventStore)
+	contextAwareEventStore := eventstore.NewContextAware(trackingEventStore)
+
+	metadata := eventually.Metadata{
+		"Test":  "value",
+		"Test2": 1,
+	}
+
+	streamID := stream.ID{
+		Type: "test-type",
+		Name: "test-name",
+	}
+
+	event := eventually.Event{
+		Payload:  internal.IntPayload(0),
+		Metadata: eventually.Metadata{},
+	}
+
+	ctx := eventstore.ContextMetadata(context.Background(), metadata)
+	newEventStreamVersion, err := contextAwareEventStore.Append(ctx, streamID, eventstore.VersionCheck(0), event)
+	assert.Equal(t, int64(1), newEventStreamVersion)
+	assert.NoError(t, err)
+
+	recordedEvents := trackingEventStore.Recorded()
+	assert.Len(t, recordedEvents, 1)
+
+	recordedEvent := recordedEvents[0]
+	assert.Equal(t, metadata, recordedEvent.Metadata)
+}

--- a/message.go
+++ b/message.go
@@ -37,6 +37,10 @@ func (m Metadata) With(key string, value interface{}) Metadata {
 // Merge merges the other Metadata provided in input with the current map.
 // Returns a pointer to the extended metadata map.
 func (m Metadata) Merge(other Metadata) Metadata {
+	if m == nil {
+		return other
+	}
+
 	for k, v := range other {
 		m[k] = v
 	}

--- a/message.go
+++ b/message.go
@@ -33,3 +33,13 @@ func (m Metadata) With(key string, value interface{}) Metadata {
 
 	return m
 }
+
+// Merge merges the other Metadata provided in input with the current map.
+// Returns a pointer to the extended metadata map.
+func (m Metadata) Merge(other Metadata) Metadata {
+	for k, v := range other {
+		m[k] = v
+	}
+
+	return m
+}


### PR DESCRIPTION
In order to provide a simple way to set common Metadata for a specific request/unit-of-work, this PR adds a `eventstore.ContextMetadata` to extend the request `context.Context` with the common Metadata, and an Event Store extension type, `eventstore.ContextAware` that appends this Metadata to each Domain Event appended using that `context.Context`.