### PR TITLE
refactor(serdes): exported serdes target []byte only

### DIFF
--- a/postgres/aggregate_repository_test.go
+++ b/postgres/aggregate_repository_test.go
@@ -109,13 +109,13 @@ func TestAggregateRepository(t *testing.T) {
 	repository := postgres.AggregateRepository[uuid.UUID, *user.User]{
 		Conn:          conn,
 		AggregateType: user.Type,
-		AggregateSerde: serdes.NewProtoJSON[*user.User, *proto.User](
+		AggregateSerde: serdes.Chain[*user.User, *proto.User, []byte](
 			user.ProtoSerde,
-			func() *proto.User { return &proto.User{} },
+			serdes.NewProtoJSON(func() *proto.User { return &proto.User{} }),
 		),
-		MessageSerde: serdes.NewProtoJSON[message.Message, *proto.Event](
+		MessageSerde: serdes.Chain[message.Message, *proto.Event, []byte](
 			user.EventProtoSerde,
-			func() *proto.Event { return &proto.Event{} },
+			serdes.NewProtoJSON(func() *proto.Event { return &proto.Event{} }),
 		),
 	}
 

--- a/postgres/event_store_test.go
+++ b/postgres/event_store_test.go
@@ -38,9 +38,9 @@ func TestEventStore(t *testing.T) {
 
 	eventStore := postgres.EventStore{
 		Conn: conn,
-		Serde: serdes.NewProtoJSON[message.Message, *proto.Event](
+		Serde: serdes.Chain[message.Message, *proto.Event, []byte](
 			user.EventProtoSerde,
-			func() *proto.Event { return &proto.Event{} },
+			serdes.NewProtoJSON(func() *proto.Event { return &proto.Event{} }),
 		),
 	}
 

--- a/serdes/chained.go
+++ b/serdes/chained.go
@@ -1,0 +1,51 @@
+package serdes
+
+import (
+	"fmt"
+
+	"github.com/get-eventually/go-eventually/core/serde"
+)
+
+type Chained[Src any, Mid any, Dst any] struct {
+	first  serde.Serde[Src, Mid]
+	second serde.Serde[Mid, Dst]
+}
+
+func (s Chained[Src, Mid, Dst]) Serialize(src Src) (Dst, error) {
+	var zeroValue Dst
+
+	mid, err := s.first.Serialize(src)
+	if err != nil {
+		return zeroValue, fmt.Errorf("serdes.Chained: first stage serializer failed, %w", err)
+	}
+
+	dst, err := s.second.Serialize(mid)
+	if err != nil {
+		return zeroValue, fmt.Errorf("serdes.Chained: second stage serializer failed, %w", err)
+	}
+
+	return dst, nil
+}
+
+func (s Chained[Src, Mid, Dst]) Deserialize(dst Dst) (Src, error) {
+	var zeroValue Src
+
+	mid, err := s.second.Deserialize(dst)
+	if err != nil {
+		return zeroValue, fmt.Errorf("serdes.Chained: first stage deserializer failed, %w", err)
+	}
+
+	src, err := s.first.Deserialize(mid)
+	if err != nil {
+		return zeroValue, fmt.Errorf("serdes.Chained: second stage deserializer failed, %w", err)
+	}
+
+	return src, nil
+}
+
+func Chain[Src any, Mid any, Dst any](
+	first serde.Serde[Src, Mid],
+	second serde.Serde[Mid, Dst],
+) Chained[Src, Mid, Dst] {
+	return Chained[Src, Mid, Dst]{first: first, second: second}
+}

--- a/serdes/chained.go
+++ b/serdes/chained.go
@@ -6,11 +6,14 @@ import (
 	"github.com/get-eventually/go-eventually/core/serde"
 )
 
+// Chained is a serde type that allows to chain two separate serdes,
+// to map from an Src to a Dst type, using a common supporting type in the middle (Mid).
 type Chained[Src any, Mid any, Dst any] struct {
 	first  serde.Serde[Src, Mid]
 	second serde.Serde[Mid, Dst]
 }
 
+// Serialize implements the serde.Serializer interface.
 func (s Chained[Src, Mid, Dst]) Serialize(src Src) (Dst, error) {
 	var zeroValue Dst
 
@@ -27,6 +30,7 @@ func (s Chained[Src, Mid, Dst]) Serialize(src Src) (Dst, error) {
 	return dst, nil
 }
 
+// Deserialize implements the serde.Deserializer interface.
 func (s Chained[Src, Mid, Dst]) Deserialize(dst Dst) (Src, error) {
 	var zeroValue Src
 
@@ -43,6 +47,7 @@ func (s Chained[Src, Mid, Dst]) Deserialize(dst Dst) (Src, error) {
 	return src, nil
 }
 
+// Chain chains together two serdes to build a new serde instance to map from Src to Dst types.
 func Chain[Src any, Mid any, Dst any](
 	first serde.Serde[Src, Mid],
 	second serde.Serde[Mid, Dst],

--- a/serdes/chained_test.go
+++ b/serdes/chained_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestChained(t *testing.T) {
-	var serde = serdes.Chain[myData, *myJSONData, []byte](
+	serde := serdes.Chain[myData, *myJSONData, []byte](
 		myDataSerde,
 		serdes.NewJSON(func() *myJSONData { return new(myJSONData) }),
 	)

--- a/serdes/chained_test.go
+++ b/serdes/chained_test.go
@@ -1,0 +1,32 @@
+package serdes_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/get-eventually/go-eventually/serdes"
+)
+
+func TestChained(t *testing.T) {
+	var serde = serdes.Chain[myData, *myJSONData, []byte](
+		myDataSerde,
+		serdes.NewJSON(func() *myJSONData { return new(myJSONData) }),
+	)
+
+	data := myData{
+		Enum:      enumFirst,
+		Something: 1,
+		Else:      "Else",
+	}
+
+	expected := []byte(`{"enum":"FIRST","something":1,"else":"Else"}`)
+
+	bytes, err := serde.Serialize(data)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, bytes)
+
+	deserialized, err := serde.Deserialize(bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, data, deserialized)
+}

--- a/serdes/json.go
+++ b/serdes/json.go
@@ -8,19 +8,12 @@ import (
 )
 
 // NewJSONSerializer returns a serializer function where the input data (Src)
-// gets serialized to JSON byte-array data using a destination model type (Dst).
-func NewJSONSerializer[Src any, Dst any](
-	serializer serde.Serializer[Src, Dst],
-) serde.SerializerFunc[Src, []byte] {
-	return func(src Src) ([]byte, error) {
-		model, err := serializer.Serialize(src)
+// gets serialized to JSON byte-array data.
+func NewJSONSerializer[T any]() serde.SerializerFunc[T, []byte] {
+	return func(t T) ([]byte, error) {
+		data, err := json.Marshal(t)
 		if err != nil {
-			return nil, fmt.Errorf("serdes.JSON: failed to serialize through serializer, %w", err)
-		}
-
-		data, err := json.Marshal(model)
-		if err != nil {
-			return nil, fmt.Errorf("serdes.JSON: failed to marshal serializer model using protojson, %w", err)
+			return nil, fmt.Errorf("serdes.JSON: failed to serialize data, %w", err)
 		}
 
 		return data, nil
@@ -28,41 +21,29 @@ func NewJSONSerializer[Src any, Dst any](
 }
 
 // NewJSONDeserializer returns a deserializer function where a byte-array
-// is deserialized into a destination model type (Dst) using JSON and then converted
-// into the desired inpud data structure (Src).
+// is deserialized into the specified data type.
 //
-// A data factory function is required for creating new instances of type `Dst`
+// A data factory function is required for creating new instances of the type
 // (especially if pointer semantics is used).
-func NewJSONDeserializer[Src any, Dst any](
-	deserializer serde.Deserializer[Src, Dst],
-	jsonFactory func() Dst,
-) serde.DeserializerFunc[Src, []byte] {
-	return func(data []byte) (Src, error) {
-		var zeroValue Src
+func NewJSONDeserializer[T any](factory func() T) serde.DeserializerFunc[T, []byte] {
+	return func(data []byte) (T, error) {
+		var zeroValue T
 
-		model := jsonFactory()
+		model := factory()
 
 		if err := json.Unmarshal(data, model); err != nil {
-			return zeroValue, fmt.Errorf("serdes.JSON: failed to marshal deserializer model using protojson, %w", err)
+			return zeroValue, fmt.Errorf("serdes.JSON: failed to deserialize data, %w", err)
 		}
 
-		root, err := deserializer.Deserialize(model)
-		if err != nil {
-			return zeroValue, fmt.Errorf("serdes.JSON: failed to deserialize through deserializer, %w", err)
-		}
-
-		return root, nil
+		return model, nil
 	}
 }
 
-// NewJSON returns a new serde instance where some data (`Src`) gets serialized to
-// and deserialized from JSON using a supporting data structure (`Dst`).
-func NewJSON[Src any, Dst any](
-	serdes serde.Serde[Src, Dst],
-	jsonFactory func() Dst,
-) serde.Fused[Src, []byte] {
-	return serde.Fused[Src, []byte]{
-		Serializer:   NewJSONSerializer[Src, Dst](serdes),
-		Deserializer: NewJSONDeserializer[Src, Dst](serdes, jsonFactory),
+// NewJSON returns a new serde instance where some data (`T`) gets serialized to
+// and deserialized from JSON as byte-array.
+func NewJSON[T any](factory func() T) serde.Fused[T, []byte] {
+	return serde.Fused[T, []byte]{
+		Serializer:   NewJSONSerializer[T](),
+		Deserializer: NewJSONDeserializer(factory),
 	}
 }

--- a/serdes/json_test.go
+++ b/serdes/json_test.go
@@ -1,0 +1,107 @@
+package serdes_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/get-eventually/go-eventually/core/serde"
+	"github.com/get-eventually/go-eventually/serdes"
+)
+
+type myEnum uint8
+
+const (
+	enumFirst myEnum = iota + 1
+	enumSecond
+	enumThird
+)
+
+type myData struct {
+	Enum      myEnum
+	Something int64
+	Else      string
+}
+
+type myJSONData struct {
+	Enum      string `json:"enum"`
+	Something int64  `json:"something"`
+	Else      string `json:"else"`
+}
+
+func serializeMyData(data myData) (*myJSONData, error) {
+	var json = new(myJSONData)
+
+	switch data.Enum {
+	case enumFirst:
+		json.Enum = "FIRST"
+	case enumSecond:
+		json.Enum = "SECOND"
+	case enumThird:
+		json.Enum = "THIRD"
+	default:
+		return nil, fmt.Errorf("failed to serialize data, unexpected data value, %v", data.Enum)
+	}
+
+	json.Something = data.Something
+	json.Else = data.Else
+
+	return json, nil
+}
+
+func deserializeMyData(json *myJSONData) (myData, error) {
+	var data myData
+
+	switch json.Enum {
+	case "FIRST":
+		data.Enum = enumFirst
+	case "SECOND":
+		data.Enum = enumSecond
+	case "THIRD":
+		data.Enum = enumThird
+	default:
+		return myData{}, fmt.Errorf("failed to deserialize data, unexpected enum value, %v", json.Enum)
+	}
+
+	data.Something = json.Something
+	data.Else = json.Else
+
+	return data, nil
+}
+
+var myDataSerde = serde.Fused[myData, *myJSONData]{
+	Serializer:   serde.SerializerFunc[myData, *myJSONData](serializeMyData),
+	Deserializer: serde.DeserializerFunc[myData, *myJSONData](deserializeMyData),
+}
+
+func TestJSON(t *testing.T) {
+	myJSONSerde := serdes.NewJSON(func() *myJSONData { return &myJSONData{} })
+
+	t.Run("it works with valid data", func(t *testing.T) {
+		myJSON := &myJSONData{
+			Enum:      "FIRST",
+			Something: 1,
+			Else:      "Else",
+		}
+
+		bytes, err := json.Marshal(myJSON)
+		require.NoError(t, err)
+
+		serialized, err := myJSONSerde.Serialize(myJSON)
+		assert.NoError(t, err)
+		assert.Equal(t, bytes, serialized)
+
+		deserialized, err := myJSONSerde.Deserialize(serialized)
+		assert.NoError(t, err)
+		assert.Equal(t, myJSON, deserialized)
+	})
+
+	t.Run("it fails deserialization of invalid json data", func(t *testing.T) {
+		deserialized, err := myJSONSerde.Deserialize([]byte("{"))
+		assert.Error(t, err)
+		assert.Zero(t, deserialized)
+	})
+}

--- a/serdes/json_test.go
+++ b/serdes/json_test.go
@@ -33,7 +33,7 @@ type myJSONData struct {
 }
 
 func serializeMyData(data myData) (*myJSONData, error) {
-	var json = new(myJSONData)
+	json := new(myJSONData)
 
 	switch data.Enum {
 	case enumFirst:

--- a/serdes/json_test.go
+++ b/serdes/json_test.go
@@ -20,6 +20,12 @@ const (
 	enumThird
 )
 
+const (
+	enumFirstString  = "FIRST"
+	enumSecondString = "SECOND"
+	enumThirdString  = "THIRD"
+)
+
 type myData struct {
 	Enum      myEnum
 	Something int64
@@ -37,11 +43,11 @@ func serializeMyData(data myData) (*myJSONData, error) {
 
 	switch data.Enum {
 	case enumFirst:
-		json.Enum = "FIRST"
+		json.Enum = enumFirstString
 	case enumSecond:
-		json.Enum = "SECOND"
+		json.Enum = enumSecondString
 	case enumThird:
-		json.Enum = "THIRD"
+		json.Enum = enumThirdString
 	default:
 		return nil, fmt.Errorf("failed to serialize data, unexpected data value, %v", data.Enum)
 	}
@@ -56,11 +62,11 @@ func deserializeMyData(json *myJSONData) (myData, error) {
 	var data myData
 
 	switch json.Enum {
-	case "FIRST":
+	case enumFirstString:
 		data.Enum = enumFirst
-	case "SECOND":
+	case enumSecondString:
 		data.Enum = enumSecond
-	case "THIRD":
+	case enumThirdString:
 		data.Enum = enumThird
 	default:
 		return myData{}, fmt.Errorf("failed to deserialize data, unexpected enum value, %v", json.Enum)

--- a/serdes/proto.go
+++ b/serdes/proto.go
@@ -8,20 +8,13 @@ import (
 	"github.com/get-eventually/go-eventually/core/serde"
 )
 
-// NewProtoSerializer returns a serializer function where the input data (Src)
-// gets serialized to Protobuf byte-array data using a destination model type (Dst).
-func NewProtoSerializer[Src any, Dst proto.Message](
-	serializer serde.Serializer[Src, Dst],
-) serde.SerializerFunc[Src, []byte] {
-	return func(src Src) ([]byte, error) {
-		model, err := serializer.Serialize(src)
+// NewProtoSerializer returns a serializer function where the input data (T)
+// gets serialized to Protobuf byte-array.
+func NewProtoSerializer[T proto.Message]() serde.SerializerFunc[T, []byte] {
+	return func(t T) ([]byte, error) {
+		data, err := proto.Marshal(t)
 		if err != nil {
-			return nil, fmt.Errorf("serdes.Proto: failed to serialize through serializer, %w", err)
-		}
-
-		data, err := proto.Marshal(model)
-		if err != nil {
-			return nil, fmt.Errorf("serdes.Proto: failed to marshal serializer model using protojson, %w", err)
+			return nil, fmt.Errorf("serdes.Proto: failed to serialize data, %w", err)
 		}
 
 		return data, nil
@@ -29,40 +22,29 @@ func NewProtoSerializer[Src any, Dst proto.Message](
 }
 
 // NewProtoDeserializer returns a deserializer function where a byte-array
-// is deserialized into a destination model type (Dst) using Protobuf and then converted
-// into the desired inpud data structure (Src).
+// is deserialized into a destination data type (T) using Protobuf.
 //
-// A data factory function is required for creating new instances of type `Dst`
+// A data factory function is required for creating new instances of type `T`
 // (especially if pointer semantics is used).
-func NewProtoDeserializer[Src any, Dst proto.Message](
-	deserializer serde.Deserializer[Src, Dst],
-	protoFactory func() Dst,
-) serde.DeserializerFunc[Src, []byte] {
-	return func(data []byte) (Src, error) {
-		var zeroValue Src
+func NewProtoDeserializer[T proto.Message](factory func() T) serde.DeserializerFunc[T, []byte] {
+	return func(data []byte) (T, error) {
+		var zeroValue T
 
-		model := protoFactory()
+		model := factory()
+
 		if err := proto.Unmarshal(data, model); err != nil {
-			return zeroValue, fmt.Errorf("serdes.Proto: failed to marshal deserializer model using protojson, %w", err)
+			return zeroValue, fmt.Errorf("serdes.Proto: failed to deseruialize data, %w", err)
 		}
 
-		root, err := deserializer.Deserialize(model)
-		if err != nil {
-			return zeroValue, fmt.Errorf("serdes.Proto: failed to deserialize through deserializer, %w", err)
-		}
-
-		return root, nil
+		return model, nil
 	}
 }
 
-// NewProto returns a new serde instance where some data (`Src`) gets serialized to
-// and deserialized from Protobuf using a supporting data structure (`Dst`).
-func NewProto[Src any, Dst proto.Message](
-	serdes serde.Serde[Src, Dst],
-	protoFactory func() Dst,
-) serde.Fused[Src, []byte] {
-	return serde.Fused[Src, []byte]{
-		Serializer:   NewProtoSerializer[Src, Dst](serdes),
-		Deserializer: NewProtoDeserializer[Src, Dst](serdes, protoFactory),
+// NewProto returns a new serde instance where some data (`T`) gets serialized to
+// and deserialized from a Protobuf byte-array.
+func NewProto[T proto.Message](factory func() T) serde.Fused[T, []byte] {
+	return serde.Fused[T, []byte]{
+		Serializer:   NewProtoSerializer[T](),
+		Deserializer: NewProtoDeserializer(factory),
 	}
 }


### PR DESCRIPTION
The previous implementation of serdes in the `serdes` package were going from `Src` to `Dst` (and back), where `Dst` is a "supporting" intermediary data structure. This however is a separate concern that can be split from the implementations.

This PR introduces the following changes:
1. A new `serdes.Chain()`, to chain two serdes together,
2. Change the `serdes.*` implementations to target a single type to byte-array instead.