### PR TITLE
feat: add initial implementation for 'query' package

### DIFF
--- a/internal/user/user_by_email.go
+++ b/internal/user/user_by_email.go
@@ -1,0 +1,122 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/get-eventually/go-eventually/event"
+	"github.com/get-eventually/go-eventually/query"
+	"github.com/get-eventually/go-eventually/version"
+)
+
+// View is a public-facing representation of a User entity.
+// Can be obtained through a Query handler.
+type View struct {
+	ID                  uuid.UUID
+	Email               string
+	FirstName, LastName string
+	BirthDate           time.Time
+
+	Version version.Version // NOTE: used to avoid re-processing of already-processed events.
+}
+
+// ErrNotFound is returned by a Query when a specific User has not been found.
+var ErrNotFound = errors.New("user: not found")
+
+var (
+	_ query.Query                              = GetByEmail("test@email.com")
+	_ query.ProcessorHandler[GetByEmail, View] = new(GetByEmailHandler)
+)
+
+// GetByEmail is a Domain Query that can be used to fetch a specific User given its email.
+type GetByEmail string
+
+// Name implements query.Query.
+func (GetByEmail) Name() string { return "GetUserByEmail" }
+
+// GetByEmailHandler is a stateful Query Handler that maintains a list of Users
+// indexed by their email.
+//
+// It can be used to answer GetByEmail queries.
+//
+// GetByEmailHandler is thread-safe.
+type GetByEmailHandler struct {
+	mx        sync.RWMutex
+	data      map[string]View
+	idToEmail map[uuid.UUID]string
+}
+
+// NewGetByEmailHandler creates a new GetByEmailHandler instance.
+func NewGetByEmailHandler() *GetByEmailHandler {
+	handler := new(GetByEmailHandler)
+	handler.data = make(map[string]View)
+	handler.idToEmail = make(map[uuid.UUID]string)
+
+	return handler
+}
+
+// Handle implements query.Handler.
+func (handler *GetByEmailHandler) Handle(_ context.Context, q query.Envelope[GetByEmail]) (View, error) {
+	handler.mx.RLock()
+	defer handler.mx.RUnlock()
+
+	user, ok := handler.data[string(q.Message)]
+	if !ok {
+		return View{}, fmt.Errorf("user.GetByEmailHandler: failed to get User by email, %w", ErrNotFound)
+	}
+
+	return user, nil
+}
+
+// Process implements event.Processor.
+func (handler *GetByEmailHandler) Process(_ context.Context, evt event.Persisted) error {
+	handler.mx.Lock()
+	defer handler.mx.Unlock()
+
+	userEvent, ok := evt.Envelope.Message.(*Event)
+	if !ok {
+		return fmt.Errorf("user.GetByEmailHandler: unexpected event type, %T", evt.Envelope.Message)
+	}
+
+	switch kind := userEvent.Kind.(type) {
+	case *WasCreated:
+		handler.idToEmail[userEvent.ID] = kind.Email
+		handler.data[kind.Email] = View{
+			ID:        userEvent.ID,
+			Email:     kind.Email,
+			FirstName: kind.FirstName,
+			LastName:  kind.LastName,
+			BirthDate: kind.BirthDate,
+			Version:   evt.Version,
+		}
+
+	case *EmailWasUpdated:
+		previousEmail, ok := handler.idToEmail[userEvent.ID]
+		if !ok {
+			return fmt.Errorf("user.GetByEmailHandler: expected id to have been registered, none found")
+		}
+
+		view, ok := handler.data[previousEmail]
+		if !ok {
+			return fmt.Errorf("user.GetByEmailHandler: expected view to be registered, none found")
+		}
+
+		if view.Version >= evt.Version {
+			return nil
+		}
+
+		view.Email = kind.Email
+		handler.idToEmail[userEvent.ID] = view.Email
+		handler.data[view.Email] = view
+
+	default:
+		return fmt.Errorf("user.GetByEmailHandler: unexpected User event kind, %T", kind)
+	}
+
+	return nil
+}

--- a/query/query.go
+++ b/query/query.go
@@ -1,0 +1,43 @@
+// Package query provides support and utilities to handle and implement
+// Domain Queries in your application.
+package query
+
+import (
+	"context"
+
+	"github.com/get-eventually/go-eventually/message"
+)
+
+// Query represents a Domain Query, a request for information.
+// Queries should be phrased in the present, imperative tense, such as "ListUsers".
+type Query message.Message
+
+// Envelope represents a message containing a Domain Query,
+// and optionally includes additional fields in the form of Metadata.
+type Envelope[T Query] message.Envelope[T]
+
+// Handler is the interface that defines a Query Handler.
+//
+// Handler accepts a specific kind of Query, evaluates it
+// and returns the desired Result.
+type Handler[T Query, R any] interface {
+	Handle(ctx context.Context, query Envelope[T]) (R, error)
+}
+
+// ToEnvelope is a convenience function that wraps the provided Query type
+// into an Envelope, with no metadata attached to it.
+func ToEnvelope[T Query](query T) Envelope[T] {
+	return Envelope[T]{
+		Message:  query,
+		Metadata: nil,
+	}
+}
+
+// HandlerFunc is a functional type that implements the Handler interface.
+// Useful for testing and stateless Handlers.
+type HandlerFunc[T Query, R any] func(ctx context.Context, query Envelope[T]) (R, error)
+
+// Handle implements xquery.Handler.
+func (f HandlerFunc[T, R]) Handle(ctx context.Context, query Envelope[T]) (R, error) {
+	return f(ctx, query)
+}

--- a/query/scenario.go
+++ b/query/scenario.go
@@ -1,0 +1,167 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/get-eventually/go-eventually/event"
+	"github.com/get-eventually/go-eventually/version"
+)
+
+// ProcessorHandler is a Query Handler that can both handle domain queries,
+// and domain events to hydrate the query model.
+//
+// To be used in the Scenario.
+type ProcessorHandler[Q Query, R any] interface {
+	Handler[Q, R]
+	event.Processor
+}
+
+// ScenarioInit is the entrypoint of the Query Handler scenario API.
+//
+// A Query Handler scenario can either set the current evaluation context
+// by using Given(), or test a "clean-slate" scenario by using When() directly.
+type ScenarioInit[Q Query, R any, T ProcessorHandler[Q, R]] struct{}
+
+// Scenario can be used to test the result of Domain Queries
+// being handled by a Query Handler.
+//
+// Query Handlers in Event-sourced systems return read-only data on request by means
+// of Domain Queries. This scenario API helps you with testing the values
+// returned by a Query Handler when handling a specific Domain Query.
+func Scenario[Q Query, R any, T ProcessorHandler[Q, R]]() ScenarioInit[Q, R, T] {
+	return ScenarioInit[Q, R, T]{}
+}
+
+// Given sets the Query Handler scenario preconditions.
+//
+// Domain Events are used in Event-sourced systems to represent a side effect
+// that has taken place in the system. In order to set a given state for the
+// system to be in while testing a specific Domain Query evaluation, you should
+// specify the Domain Events that have happened thus far.
+//
+// When you're testing Domain Queries with a clean-slate system, you should either specify
+// no Domain Events, or skip directly to When().
+func (sc ScenarioInit[Q, R, T]) Given(events ...event.Persisted) ScenarioGiven[Q, R, T] {
+	return ScenarioGiven[Q, R, T]{
+		given: events,
+	}
+}
+
+// When provides the Domain Query to evaluate.
+func (sc ScenarioInit[Q, R, T]) When(q Envelope[Q]) ScenarioWhen[Q, R, T] {
+	//nolint:exhaustruct // Zero values are fine here.
+	return ScenarioWhen[Q, R, T]{
+		when: q,
+	}
+}
+
+// ScenarioGiven is the state of the scenario once
+// a set of Domain Events have been provided using Given(), to represent
+// the state of the system at the time of evaluating a Domain Event.
+type ScenarioGiven[Q Query, R any, T ProcessorHandler[Q, R]] struct {
+	given []event.Persisted
+}
+
+// When provides the Command to evaluate.
+func (sc ScenarioGiven[Q, R, T]) When(q Envelope[Q]) ScenarioWhen[Q, R, T] {
+	return ScenarioWhen[Q, R, T]{
+		ScenarioGiven: sc,
+		when:          q,
+	}
+}
+
+// ScenarioWhen is the state of the scenario once the state of the
+// system and the Domain Query to evaluate has been provided.
+type ScenarioWhen[Q Query, R any, T ProcessorHandler[Q, R]] struct {
+	ScenarioGiven[Q, R, T]
+	when Envelope[Q]
+}
+
+// Then sets a positive expectation on the scenario outcome, to produce
+// the Query Result provided in input.
+func (sc ScenarioWhen[Q, R, T]) Then(result R) ScenarioThen[Q, R, T] {
+	//nolint:exhaustruct // Zero values are fine here.
+	return ScenarioThen[Q, R, T]{
+		ScenarioWhen: sc,
+		then:         result,
+	}
+}
+
+// ThenError sets a negative expectation on the scenario outcome,
+// to produce an error value that is similar to the one provided in input.
+//
+// Error assertion happens using errors.Is(), so the error returned
+// by the Query Handler is unwrapped until the cause error to match
+// the provided expectation.
+func (sc ScenarioWhen[Q, R, T]) ThenError(err error) ScenarioThen[Q, R, T] {
+	//nolint:exhaustruct // Zero values are fine here.
+	return ScenarioThen[Q, R, T]{
+		ScenarioWhen: sc,
+		wantError:    true,
+		thenError:    err,
+	}
+}
+
+// ThenFails sets a negative expectation on the scenario outcome,
+// to fail the Domain Query evaluation with no particular assertion on the error returned.
+//
+// This is useful when the error returned is not important for the Domain Query
+// you're trying to test.
+func (sc ScenarioWhen[Q, R, T]) ThenFails() ScenarioThen[Q, R, T] {
+	//nolint:exhaustruct // Zero values are fine here.
+	return ScenarioThen[Q, R, T]{
+		ScenarioWhen: sc,
+		wantError:    true,
+	}
+}
+
+// ScenarioThen is the state of the scenario once the preconditions
+// and expectations have been fully specified.
+type ScenarioThen[Q Query, R any, T ProcessorHandler[Q, R]] struct {
+	ScenarioWhen[Q, R, T]
+
+	then      R
+	thenError error
+	wantError bool
+}
+
+// AssertOn performs the specified expectations of the scenario, using the Query Handler
+// instance produced by the provided factory function.
+func (sc ScenarioThen[Q, R, T]) AssertOn( //nolint:gocritic
+	t *testing.T,
+	handlerFactory func(es event.Store) T,
+) {
+	ctx := context.Background()
+
+	eventStore := event.NewInMemoryStore()
+	queryHandler := handlerFactory(eventStore)
+
+	for _, evt := range sc.given {
+		_, err := eventStore.Append(ctx, evt.StreamID, version.CheckExact(evt.Version-1), evt.Envelope)
+		require.NoError(t, err, "failed to record event on the event store", evt)
+
+		err = queryHandler.Process(ctx, evt)
+		require.NoError(t, err, "event failed to be processed with the query handler", evt)
+	}
+
+	actual, err := queryHandler.Handle(ctx, sc.when)
+
+	if !sc.wantError {
+		assert.NoError(t, err)
+		assert.Equal(t, sc.then, actual)
+
+		return
+	}
+
+	if !assert.Error(t, err) {
+		return
+	}
+
+	if sc.thenError != nil {
+		assert.ErrorIs(t, err, sc.thenError)
+	}
+}

--- a/query/scenario_test.go
+++ b/query/scenario_test.go
@@ -25,7 +25,7 @@ func TestScenario(t *testing.T) {
 		BirthDate: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
 	}
 
-	makeQueryHandler := func(es event.Store) *user.GetByEmailHandler {
+	makeQueryHandler := func(_ event.Store) *user.GetByEmailHandler {
 		return user.NewGetByEmailHandler()
 	}
 

--- a/query/scenario_test.go
+++ b/query/scenario_test.go
@@ -1,0 +1,62 @@
+package query_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/get-eventually/go-eventually/event"
+	"github.com/get-eventually/go-eventually/internal/user"
+	"github.com/get-eventually/go-eventually/query"
+)
+
+func TestScenario(t *testing.T) {
+	id := uuid.New()
+	now := time.Now()
+	before := now.Add(-1 * time.Minute)
+
+	expected := user.View{
+		ID:        id,
+		Version:   1,
+		Email:     "me@email.com",
+		FirstName: "John",
+		LastName:  "Doe",
+		BirthDate: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	makeQueryHandler := func(es event.Store) *user.GetByEmailHandler {
+		return user.NewGetByEmailHandler()
+	}
+
+	t.Run("returns the expected User by its email when it was just created", func(t *testing.T) {
+		query.
+			Scenario[user.GetByEmail, user.View, *user.GetByEmailHandler]().
+			Given(event.Persisted{
+				StreamID: event.StreamID(id.String()),
+				Version:  1,
+				Envelope: event.ToEnvelope(&user.Event{
+					ID:         id,
+					RecordTime: before,
+					Kind: &user.WasCreated{
+						FirstName: expected.FirstName,
+						LastName:  expected.LastName,
+						BirthDate: expected.BirthDate,
+						Email:     expected.Email,
+					},
+				}),
+			}).
+			When(query.ToEnvelope(user.GetByEmail(expected.Email))).
+			Then(expected).
+			AssertOn(t, makeQueryHandler)
+	})
+
+	t.Run("returns user.ErrNotFound if the requested User does not exist", func(t *testing.T) {
+		query.
+			Scenario[user.GetByEmail, user.View, *user.GetByEmailHandler]().
+			Given().
+			When(query.ToEnvelope(user.GetByEmail(expected.Email))).
+			ThenError(user.ErrNotFound).
+			AssertOn(t, makeQueryHandler)
+	})
+}


### PR DESCRIPTION
This PR adds an initial implementation for a `query` package.

The `query` package adds support for Domain Queries, also known as Projections in the Event Sourcing realm.

The PR contains an in-memory Domain Query Handler as an example, mostly to test the Query Scenario API.
