### PR TITLE
fix(release): drop package-name from release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -22,7 +22,6 @@
   ],
   "packages": {
     ".": {
-      "package-name": "go-eventually",
       "changelog-path": "docs/CHANGELOG.md"
     }
   }


### PR DESCRIPTION
## Summary

Removes `package-name` from `release-please-config.json`. This field was triggering an upstream release-please bug that left merged release PRs stuck in `autorelease: pending` and prevented tag/GitHub-Release creation.

## Root cause

With `include-component-in-tag: false` (as we have configured), release-please's PR-creation leg correctly uses an empty component. But its PR-parsing leg — used during `buildReleases` to decide whether to cut a tag — ignores that flag and falls through to `getBranchComponent()`, which returns the `package-name` value (\"go-eventually\"). The configured component (\"go-eventually\") is then compared against the component parsed from the branch name (\`release-please--branches--main\`), which is \`undefined\`. Mismatch → early return → no tag.

This is the upstream bug tracked at [googleapis/release-please#2214](https://github.com/googleapis/release-please/issues/2214), open since Feb 2024.

## Evidence from the stuck workflow run

Run [#24731049954](https://github.com/get-eventually/go-eventually/actions/runs/24731049954) (post-merge of #327) logged:

\`\`\`
⚠ PR component: undefined does not match configured component: go-eventually
\`\`\`

and then:

\`\`\`
⚠ There are untagged, merged release PRs outstanding - aborting
\`\`\`

The tag `v0.4.0` was never created even though PR #327 was merged successfully.

## Fix

Remove `package-name` — it provides no value here:

- We don't use components in tags (`include-component-in-tag: false`).
- There's no `version-file` to write the package name into.
- The tag name is always the bare `vMAJOR.MINOR.PATCH` at repo root.

With `package-name` gone, `getBranchComponent()` returns `''`, which matches the empty component parsed from the release branch name, and `buildReleases` no longer bails.

## Recovery for the stuck v0.4.0

The stalled `v0.4.0` tag will be created manually (separately from this PR) by tagging commit `5e41a02026adf5f4d585aa4b93b9a47bf3326c3f` and flipping PR #327's label from `autorelease: pending` → `autorelease: tagged`. After that, this config fix ensures the next release cycle (`v0.4.1` for this commit) tags automatically when its release PR is merged.