### PR TITLE
feat!: replace channel-based event streaming with message.Stream iterator

### DIFF
--- a/aggregate/event_sourced_repository.go
+++ b/aggregate/event_sourced_repository.go
@@ -4,21 +4,28 @@ import (
 	"context"
 	"fmt"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/get-eventually/go-eventually/event"
 	"github.com/get-eventually/go-eventually/serde"
 	"github.com/get-eventually/go-eventually/version"
 )
 
-// RehydrateFromEvents rehydrates an Aggregate Root from a read-only Event Stream.
-func RehydrateFromEvents[I ID](root Root[I], eventStream event.StreamRead) error {
-	for event := range eventStream {
-		if err := root.Apply(event.Message); err != nil {
+// RehydrateFromEvents rehydrates an Aggregate Root from a Stream of persisted
+// Domain Events.
+//
+// The Stream is iterated to completion or until the Aggregate Root's Apply
+// method returns an error. After iteration, the stream's terminal error (if
+// any) is checked via Stream.Err.
+func RehydrateFromEvents[I ID](root Root[I], stream *event.Stream) error {
+	for evt := range stream.Iter() {
+		if err := root.Apply(evt.Message); err != nil {
 			return fmt.Errorf("aggregate.RehydrateFromEvents: failed to record event, %w", err)
 		}
 
-		root.setVersion(event.Version)
+		root.setVersion(evt.Version)
+	}
+
+	if err := stream.Err(); err != nil {
+		return fmt.Errorf("aggregate.RehydrateFromEvents: streaming failed, %w", err)
 	}
 
 	return nil
@@ -74,29 +81,12 @@ func NewEventSourcedRepository[I ID, T Root[I]](eventStore event.Store, typ Type
 func (repo EventSourcedRepository[I, T]) Get(ctx context.Context, id I) (T, error) {
 	var zeroValue T
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	streamID := event.StreamID(id.String())
-	eventStream := make(event.Stream, 1)
-
-	group, ctx := errgroup.WithContext(ctx)
-	group.Go(func() error {
-		if err := repo.eventStore.Stream(ctx, eventStream, streamID, version.SelectFromBeginning); err != nil {
-			return fmt.Errorf("aggregate.EventSourcedRepository: failed while reading event from stream, %w", err)
-		}
-
-		return nil
-	})
+	stream := repo.eventStore.Stream(ctx, streamID, version.SelectFromBeginning)
 
 	root := repo.typ.Factory()
-
-	if err := RehydrateFromEvents(root, eventStream); err != nil {
+	if err := RehydrateFromEvents(root, stream); err != nil {
 		return zeroValue, fmt.Errorf("aggregate.EventSourcedRepository: failed to rehydrate aggregate root, %w", err)
-	}
-
-	if err := group.Wait(); err != nil {
-		return zeroValue, err
 	}
 
 	if root.Version() == 0 {

--- a/event/store.go
+++ b/event/store.go
@@ -3,43 +3,49 @@ package event
 import (
 	"context"
 
+	"github.com/get-eventually/go-eventually/message"
 	"github.com/get-eventually/go-eventually/version"
 )
 
-// Stream represents a stream of persisted Domain Events coming from some
-// stream-able source of data, like an Event Store.
-type Stream = chan Persisted
-
-// StreamWrite provides write-only access to an event.Stream object.
-type StreamWrite chan<- Persisted
-
-// StreamRead provides read-only access to an event.Stream object.
-type StreamRead <-chan Persisted
-
-// SliceToStream converts a slice of event.Persisted domain events to an event.Stream type.
+// Stream is a single-use, iterator-backed sequence of persisted Domain Events
+// coming from some stream-able source of data, like an Event Store.
 //
-// The event.Stream channel has the same buffer size as the input slice.
-//
-// The channel returned by the function contains all the original slice elements
-// and is already closed.
-func SliceToStream(events []Persisted) Stream {
-	ch := make(chan Persisted, len(events))
-	defer close(ch)
+// Stream is an alias for message.Stream[Persisted]. See [message.Stream] for
+// the full iteration and error-reporting contract.
+type Stream = message.Stream[Persisted]
 
-	for _, event := range events {
-		ch <- event
-	}
-
-	return ch
+// NewStream wraps a producer into a Stream. Convenience re-export of
+// [message.NewStream] for values of type [Persisted].
+func NewStream(produce func(yield func(Persisted) bool) error) *Stream {
+	return message.NewStream(produce)
 }
 
-// Streamer is an event.Store trait used to open a specific Event Stream and stream it back
-// in the application.
+// SliceToStream returns a Stream that yields each element of events in order.
+//
+// Useful for tests and for adapting fully-buffered results.
+func SliceToStream(events []Persisted) *Stream {
+	return NewStream(func(yield func(Persisted) bool) error {
+		for _, evt := range events {
+			if !yield(evt) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+}
+
+// Streamer is an event.Store trait used to open a specific Event Stream and
+// stream it back in the application.
+//
+// Implementations should respect ctx cancellation between yields by checking
+// ctx.Err() at loop boundaries inside the producer.
 type Streamer interface {
-	Stream(ctx context.Context, stream StreamWrite, id StreamID, selector version.Selector) error
+	Stream(ctx context.Context, id StreamID, selector version.Selector) *Stream
 }
 
-// Appender is an event.Store trait used to append new Domain Events in the Event Stream.
+// Appender is an event.Store trait used to append new Domain Events in the
+// Event Stream.
 type Appender interface {
 	Append(ctx context.Context, id StreamID, expected version.Check, events ...Envelope) (version.Version, error)
 }

--- a/event/store_inmemory.go
+++ b/event/store_inmemory.go
@@ -25,58 +25,50 @@ func NewInMemoryStore() *InMemoryStore {
 	}
 }
 
-func contextErr(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("event.InMemoryStore: context error, %w", err)
-	}
-
-	return nil
-}
-
-// Stream streams committed events in the Event Store onto the provided EventStream,
-// from the specified Global Sequence Number in `from`, based on the provided stream.Target.
+// Stream returns a Stream over the committed events for the given Event Stream,
+// filtered by the provided version.Selector.
 //
-// Note: this call is synchronous, and will return when all the Events
-// have been successfully written to the provided EventStream, or when
-// the context has been canceled.
+// The returned Stream holds a read-lock on the underlying store for the
+// duration of iteration; long-paused iterations will block concurrent writers.
 //
-// This method fails only when the context is canceled.
+// Iteration stops if the consumer abandons the range loop or if the context
+// is canceled between yields.
 func (es *InMemoryStore) Stream(
 	ctx context.Context,
-	eventStream StreamWrite,
 	id StreamID,
 	selector version.Selector,
-) error {
-	es.mx.RLock()
-	defer es.mx.RUnlock()
-	defer close(eventStream)
+) *Stream {
+	return NewStream(func(yield func(Persisted) bool) error {
+		es.mx.RLock()
+		defer es.mx.RUnlock()
 
-	events, ok := es.events[id]
-	if !ok {
+		events, ok := es.events[id]
+		if !ok {
+			return nil
+		}
+
+		for i, evt := range events {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("event.InMemoryStore: context error, %w", err)
+			}
+
+			eventVersion := version.Version(i) + 1
+
+			if eventVersion < selector.From {
+				continue
+			}
+
+			if !yield(Persisted{
+				Envelope: evt,
+				StreamID: id,
+				Version:  eventVersion,
+			}) {
+				return nil
+			}
+		}
+
 		return nil
-	}
-
-	for i, evt := range events {
-		eventVersion := version.Version(i) + 1
-
-		if eventVersion < selector.From {
-			continue
-		}
-
-		persistedEvent := Persisted{
-			Envelope: evt,
-			StreamID: id,
-			Version:  eventVersion,
-		}
-
-		select {
-		case eventStream <- persistedEvent:
-		case <-ctx.Done():
-			return contextErr(ctx)
-		}
-	}
-
-	return nil
+	})
 }
 
 // Append inserts the specified Domain Events into the Event Stream specified

--- a/event/store_inmemory_test.go
+++ b/event/store_inmemory_test.go
@@ -1,0 +1,121 @@
+package event_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/get-eventually/go-eventually/event"
+	"github.com/get-eventually/go-eventually/message"
+	"github.com/get-eventually/go-eventually/version"
+)
+
+type noopMessage struct{ id int }
+
+func (noopMessage) Name() string { return "noop" }
+
+var _ message.Message = noopMessage{}
+
+const testStreamID event.StreamID = "stream"
+
+func appendN(t *testing.T, store *event.InMemoryStore, n int) {
+	t.Helper()
+
+	envelopes := make([]event.Envelope, 0, n)
+	for i := range n {
+		envelopes = append(envelopes, event.Envelope{
+			Message:  noopMessage{id: i},
+			Metadata: nil,
+		})
+	}
+
+	_, err := store.Append(t.Context(), testStreamID, version.Any, envelopes...)
+	require.NoError(t, err)
+}
+
+func collectIDs(stream *event.Stream) []int {
+	ids := make([]int, 0)
+	for evt := range stream.Iter() {
+		ids = append(ids, evt.Message.(noopMessage).id) //nolint:errcheck,forcetypeassert // test helper
+	}
+
+	return ids
+}
+
+func TestInMemoryStore_Stream_EmptyStream(t *testing.T) {
+	store := event.NewInMemoryStore()
+
+	stream := store.Stream(t.Context(), "missing", version.SelectFromBeginning)
+
+	count := 0
+	for range stream.Iter() {
+		count++
+	}
+
+	require.NoError(t, stream.Err())
+	assert.Equal(t, 0, count)
+}
+
+func TestInMemoryStore_Stream_YieldsAllEvents(t *testing.T) {
+	store := event.NewInMemoryStore()
+	appendN(t, store, 3)
+
+	stream := store.Stream(t.Context(), testStreamID, version.SelectFromBeginning)
+	got := collectIDs(stream)
+
+	require.NoError(t, stream.Err())
+	assert.Equal(t, []int{0, 1, 2}, got)
+}
+
+func TestInMemoryStore_Stream_SelectorFiltersFromVersion(t *testing.T) {
+	store := event.NewInMemoryStore()
+	appendN(t, store, 5)
+
+	stream := store.Stream(t.Context(), testStreamID, version.Selector{From: 3})
+	got := collectIDs(stream)
+
+	require.NoError(t, stream.Err())
+	// Versions start at 1, so selector.From=3 yields events at index 2,3,4.
+	assert.Equal(t, []int{2, 3, 4}, got)
+}
+
+func TestInMemoryStore_Stream_ConsumerAbandonment(t *testing.T) {
+	store := event.NewInMemoryStore()
+	appendN(t, store, 10)
+
+	stream := store.Stream(t.Context(), testStreamID, version.SelectFromBeginning)
+
+	got := make([]int, 0, 3)
+	for evt := range stream.Iter() {
+		//nolint:errcheck,forcetypeassert // test helper
+		got = append(got, evt.Message.(noopMessage).id)
+
+		if len(got) == 3 {
+			break
+		}
+	}
+
+	require.NoError(t, stream.Err(), "abandonment is not a failure")
+	assert.Equal(t, []int{0, 1, 2}, got)
+}
+
+func TestInMemoryStore_Stream_ContextCancellation(t *testing.T) {
+	store := event.NewInMemoryStore()
+	appendN(t, store, 5)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel before iteration starts
+
+	stream := store.Stream(ctx, testStreamID, version.SelectFromBeginning)
+
+	count := 0
+	for range stream.Iter() {
+		count++
+	}
+
+	require.Error(t, stream.Err())
+	require.ErrorIs(t, stream.Err(), context.Canceled)
+	assert.Equal(t, 0, count)
+}

--- a/event/store_tracking.go
+++ b/event/store_tracking.go
@@ -11,8 +11,12 @@ import (
 // committed to the inner Event Store.
 //
 // Useful for tests assertion.
+//
+// TrackingStore embeds a full [Store]: Stream is inherited through the
+// embedded value; only Append is overridden to record events as they are
+// appended.
 type TrackingStore struct {
-	Appender
+	Store
 
 	mx       sync.RWMutex
 	recorded []Persisted
@@ -20,9 +24,9 @@ type TrackingStore struct {
 
 // NewTrackingStore wraps an Event Store to capture events that get
 // appended to it.
-func NewTrackingStore(appender Appender) *TrackingStore {
+func NewTrackingStore(store Store) *TrackingStore {
 	return &TrackingStore{
-		Appender: appender,
+		Store:    store,
 		mx:       sync.RWMutex{},
 		recorded: nil,
 	}
@@ -54,7 +58,7 @@ func (es *TrackingStore) Append(
 	es.mx.Lock()
 	defer es.mx.Unlock()
 
-	v, err := es.Appender.Append(ctx, id, expected, events...)
+	v, err := es.Store.Append(ctx, id, expected, events...)
 	if err != nil {
 		return v, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
-	golang.org/x/sync v0.20.0
 	google.golang.org/genproto v0.0.0-20260420184626-e10c466a9529
 	google.golang.org/protobuf v1.36.11
 )
@@ -74,6 +73,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/message/stream.go
+++ b/message/stream.go
@@ -1,0 +1,79 @@
+package message
+
+import (
+	"errors"
+	"iter"
+)
+
+// ErrAlreadyIterated is returned by Stream.Err when Iter is called more than once.
+//
+// The second and subsequent iterations yield nothing; Err transitions to this
+// sentinel value.
+var ErrAlreadyIterated = errors.New("message.Stream: already iterated")
+
+// Stream is a single-use, iterator-backed sequence of values of type T.
+//
+// Producers are written as callbacks that push values via yield and return a
+// terminal error if the sequence cannot be completed. Consumers iterate via
+// [Stream.Iter] and check [Stream.Err] at the end:
+//
+//	for v := range stream.Iter() {
+//		// handle v
+//	}
+//	if err := stream.Err(); err != nil {
+//		// handle failure
+//	}
+//
+// Consumer abandonment (break in the range loop) is NOT a failure; Err returns
+// nil in that case.
+//
+// Stream is single-use. Calling [Stream.Iter] more than once yields an empty
+// sequence and sets [Stream.Err] to [ErrAlreadyIterated].
+//
+// Ctx cancellation is the producer's responsibility: producers should check
+// ctx.Err() at loop boundaries and return it to signal cancellation.
+type Stream[T any] struct {
+	produce  func(yield func(T) bool) error
+	iterated bool
+	err      error
+}
+
+// NewStream returns a Stream backed by the given producer.
+//
+// The producer is invoked lazily when [Stream.Iter] is called. It must push
+// each value via yield and respect yield's bool return: if yield returns
+// false, the producer should stop and return nil.
+//
+// A non-nil error returned by the producer is captured and surfaced via
+// [Stream.Err].
+func NewStream[T any](produce func(yield func(T) bool) error) *Stream[T] {
+	return &Stream[T]{
+		produce:  produce,
+		iterated: false,
+		err:      nil,
+	}
+}
+
+// Iter returns an [iter.Seq] over the stream's values.
+//
+// Iter is single-use: calling it more than once returns an empty sequence and
+// sets [Stream.Err] to [ErrAlreadyIterated].
+func (s *Stream[T]) Iter() iter.Seq[T] {
+	if s.iterated {
+		s.err = ErrAlreadyIterated
+
+		return func(_ func(T) bool) {}
+	}
+
+	s.iterated = true
+
+	return func(yield func(T) bool) {
+		s.err = s.produce(yield)
+	}
+}
+
+// Err returns the terminal error of the stream, or nil if the stream completed
+// without error (including the case of consumer abandonment).
+//
+// Err is valid at any time; before [Stream.Iter] is called, Err returns nil.
+func (s *Stream[T]) Err() error { return s.err }

--- a/message/stream_test.go
+++ b/message/stream_test.go
@@ -1,0 +1,125 @@
+package message_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/get-eventually/go-eventually/message"
+)
+
+func TestStream_EmptyProducer(t *testing.T) {
+	s := message.NewStream(func(_ func(int) bool) error {
+		return nil
+	})
+
+	got := make([]int, 0)
+	for v := range s.Iter() {
+		got = append(got, v)
+	}
+
+	require.NoError(t, s.Err())
+	assert.Empty(t, got)
+}
+
+func TestStream_YieldsAllValues(t *testing.T) {
+	want := []int{1, 2, 3}
+
+	s := message.NewStream(func(yield func(int) bool) error {
+		for _, v := range want {
+			if !yield(v) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	got := make([]int, 0, len(want))
+	for v := range s.Iter() {
+		got = append(got, v)
+	}
+
+	require.NoError(t, s.Err())
+	assert.Equal(t, want, got)
+}
+
+func TestStream_ProducerError(t *testing.T) {
+	wantErr := errors.New("boom")
+
+	s := message.NewStream(func(yield func(int) bool) error {
+		yield(1)
+
+		return wantErr
+	})
+
+	got := make([]int, 0, 1)
+	for v := range s.Iter() {
+		got = append(got, v)
+	}
+
+	require.ErrorIs(t, s.Err(), wantErr)
+	assert.Equal(t, []int{1}, got)
+}
+
+func TestStream_ConsumerAbandonment(t *testing.T) {
+	s := message.NewStream(func(yield func(int) bool) error {
+		for i := 1; i <= 10; i++ {
+			if !yield(i) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	got := make([]int, 0, 3)
+	for v := range s.Iter() {
+		got = append(got, v)
+
+		if len(got) == 3 {
+			break
+		}
+	}
+
+	require.NoError(t, s.Err(), "abandonment is not a failure")
+	assert.Equal(t, []int{1, 2, 3}, got)
+}
+
+func TestStream_IterSingleUse(t *testing.T) {
+	s := message.NewStream(func(yield func(int) bool) error {
+		for _, v := range []int{1, 2, 3} {
+			if !yield(v) {
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	// First iteration completes normally.
+	got := make([]int, 0, 3)
+	for v := range s.Iter() {
+		got = append(got, v)
+	}
+
+	require.NoError(t, s.Err())
+	assert.Equal(t, []int{1, 2, 3}, got)
+
+	// Second iteration yields nothing and sets ErrAlreadyIterated.
+	for v := range s.Iter() {
+		t.Fatalf("unexpected yield on second Iter() call: %v", v)
+	}
+
+	require.ErrorIs(t, s.Err(), message.ErrAlreadyIterated)
+}
+
+func TestStream_ErrBeforeIter(t *testing.T) {
+	s := message.NewStream(func(_ func(int) bool) error {
+		return errors.New("unused")
+	})
+
+	require.NoError(t, s.Err(), "Err should be nil before Iter is called")
+}

--- a/opentelemetry/event_store.go
+++ b/opentelemetry/event_store.go
@@ -80,38 +80,52 @@ func NewInstrumentedEventStore(eventStore event.Store, options ...Option) (*Inst
 	return ies, nil
 }
 
-// Stream calls the wrapped event.Store.Stream method and records metrics and traces around it.
+// Stream calls the wrapped event.Store.Stream method and records metrics and
+// traces around it.
+//
+// The recorded duration covers the full iteration of the returned Stream
+// (including consumer backpressure), not just the time to open the stream.
 func (ies *InstrumentedEventStore) Stream(
 	ctx context.Context,
-	stream event.StreamWrite,
 	id event.StreamID,
 	selector version.Selector,
-) (err error) {
+) *event.Stream {
 	attributes := []attribute.KeyValue{
 		EventStreamIDKey.String(string(id)),
 		EventStreamVersionSelectorKey.Int64(int64(selector.From)),
 	}
 
-	ctx, span := ies.tracer.Start(ctx, "event.Store.Stream", trace.WithAttributes(attributes...))
-	start := time.Now()
+	return event.NewStream(func(yield func(event.Persisted) bool) error {
+		ctx, span := ies.tracer.Start(ctx, "event.Store.Stream", trace.WithAttributes(attributes...))
+		start := time.Now()
 
-	defer func() {
-		duration := time.Since(start)
-		ies.streamDuration.Record(ctx, duration.Milliseconds(), metric.WithAttributes(
-			ErrorAttribute.Bool(err != nil),
-		))
+		inner := ies.eventStore.Stream(ctx, id, selector)
 
-		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
+		var producerErr error
+
+		defer func() {
+			ies.streamDuration.Record(ctx, time.Since(start).Milliseconds(), metric.WithAttributes(
+				ErrorAttribute.Bool(producerErr != nil),
+			))
+
+			if producerErr != nil {
+				span.RecordError(producerErr)
+				span.SetStatus(codes.Error, producerErr.Error())
+			}
+
+			span.End()
+		}()
+
+		for evt := range inner.Iter() {
+			if !yield(evt) {
+				return nil
+			}
 		}
 
-		span.End()
-	}()
+		producerErr = inner.Err()
 
-	err = ies.eventStore.Stream(ctx, stream, id, selector)
-
-	return err
+		return producerErr
+	})
 }
 
 // Append calls the wrapped event.Store.Append method and records metrics and traces around it.

--- a/postgres/event_store.go
+++ b/postgres/event_store.go
@@ -38,64 +38,61 @@ func NewEventStore(conn *pgxpool.Pool, messageSerde serde.Bytes[message.Message]
 // Stream implements the event.Streamer interface.
 func (es EventStore) Stream(
 	ctx context.Context,
-	stream event.StreamWrite,
 	id event.StreamID,
 	selector version.Selector,
-) error {
-	defer close(stream)
-
-	rows, err := es.conn.Query(
-		ctx,
-		`SELECT version, event, metadata FROM events
-		WHERE event_stream_id = $1 AND version >= $2
-		ORDER BY version`,
-		id, selector.From,
-	)
-	if err != nil {
-		return fmt.Errorf("postgres.EventStore: failed to query events table, %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var (
-			rawEvent     []byte
-			rawMetadata  json.RawMessage
-			eventVersion version.Version
+) *event.Stream {
+	return event.NewStream(func(yield func(event.Persisted) bool) error {
+		rows, err := es.conn.Query(
+			ctx,
+			`SELECT version, event, metadata FROM events
+			WHERE event_stream_id = $1 AND version >= $2
+			ORDER BY version`,
+			id, selector.From,
 		)
-
-		if err := rows.Scan(&eventVersion, &rawEvent, &rawMetadata); err != nil {
-			return fmt.Errorf("postgres.EventStore: failed to scan next row, %w", err)
-		}
-
-		msg, err := es.messageSerde.Deserialize(rawEvent)
 		if err != nil {
-			return fmt.Errorf("postgres.EventStore: failed to deserialize event, %w", err)
+			return fmt.Errorf("postgres.EventStore: failed to query events table, %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var (
+				rawEvent     []byte
+				rawMetadata  json.RawMessage
+				eventVersion version.Version
+			)
+
+			if err := rows.Scan(&eventVersion, &rawEvent, &rawMetadata); err != nil {
+				return fmt.Errorf("postgres.EventStore: failed to scan next row, %w", err)
+			}
+
+			msg, err := es.messageSerde.Deserialize(rawEvent)
+			if err != nil {
+				return fmt.Errorf("postgres.EventStore: failed to deserialize event, %w", err)
+			}
+
+			var metadata message.Metadata
+			if err := json.Unmarshal(rawMetadata, &metadata); err != nil {
+				return fmt.Errorf("postgres.EventStore: failed to deserialize metadata, %w", err)
+			}
+
+			if !yield(event.Persisted{
+				StreamID: id,
+				Version:  eventVersion,
+				Envelope: event.Envelope{
+					Message:  msg,
+					Metadata: metadata,
+				},
+			}) {
+				return nil
+			}
 		}
 
-		var metadata message.Metadata
-		if err := json.Unmarshal(rawMetadata, &metadata); err != nil {
-			return fmt.Errorf("postgres.EventStore: failed to deserialize metadata, %w", err)
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("postgres.EventStore: failed to iterate events rows, %w", err)
 		}
 
-		select {
-		case stream <- event.Persisted{
-			StreamID: id,
-			Version:  eventVersion,
-			Envelope: event.Envelope{
-				Message:  msg,
-				Metadata: metadata,
-			},
-		}:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-
-	if err := rows.Err(); err != nil {
-		return fmt.Errorf("postgres.EventStore: failed to iterate events rows, %w", err)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 // Append implements event.Store.


### PR DESCRIPTION
This PR replaces the channel-based `event.Stream` API with `message.Stream[T]`, a single-use iterator-backed stream type. Event consumers now write idiomatic range loops with a terminal error check instead of managing channels, goroutines, and `errgroup`s.

```go
// before
stream := make(event.Stream, 1)
go func() { _ = store.Stream(ctx, stream, id, sel) }()
for evt := range stream { ... }

// after
stream := store.Stream(ctx, id, sel)
for evt := range stream.Iter() { ... }
if err := stream.Err(); err != nil { ... }
```

The `message.Stream[T]` shape uses a producer callback with an `error` return, which `Stream` captures and surfaces via `Err()`. This avoids the `iter.Seq2[T, error]` tuple-check-on-every-iteration wart while staying composable with the stdlib `iter` package via `Iter()`.

## Breaking changes

- `event.Store.Stream` signature: `(ctx, StreamWrite, id, selector) error` → `(ctx, id, selector) *event.Stream`
- `event.StreamWrite`, `event.StreamRead`, channel-based `event.Stream`: **removed**
- `event.SliceToStream`: return type `chan Persisted` → `*event.Stream`
- `aggregate.RehydrateFromEvents`: parameter type `event.StreamRead` → `*event.Stream`
- `event.NewTrackingStore`: parameter `Appender` → `Store`
- `event.TrackingStore`: embeds `Store` instead of `Appender`; `Stream` promoted through embedding

## Migration

Use the "before/after" snippet at the top. `event.NewTrackingStore` callers lose the ability to pass a bare `Appender` — this is intentional; previously `TrackingStore` couldn't satisfy `event.Store` at all, making it awkward to use with the aggregate repository.